### PR TITLE
Building 1.6

### DIFF
--- a/build/Rakefile
+++ b/build/Rakefile
@@ -101,7 +101,7 @@ namespace :build do
   end
 
   desc 'Sign RPMs'
-  task :gpgsign do |task|
+  task :gpgsign => :bootstrap do |task|
     puts "== #{task.name} ==".blue
     get_rpms(OUTPUT_DIR).each do |rpm|
       puts "\tGPG signing #{rpm}".blue

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -47,7 +47,7 @@ ondemand-runtime:
   versions:
     - 1.6-1
 ondemand:
-  - 1.5.5-1
+  - 1.6.0-1
 
 # compute
 ondemand-compute:

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -45,7 +45,7 @@ ondemand-runtime:
     - ondemand-runtime
     - ondemand-scldevel
   versions:
-    - 1.5-5
+    - 1.6-1
 ondemand:
   - 1.5.5-1
 

--- a/web/ondemand-runtime/ondemand-runtime.spec
+++ b/web/ondemand-runtime/ondemand-runtime.spec
@@ -9,8 +9,8 @@
 %global apache httpd24
 
 Name:      ondemand-runtime
-Version:   1.5
-Release:   5%{?dist}
+Version:   1.6
+Release:   1%{?dist}
 Summary:   Package that handles %{scl} Software Collection.
 License:   MIT
 

--- a/web/ondemand/ondemand.spec
+++ b/web/ondemand/ondemand.spec
@@ -31,20 +31,20 @@ Source0:   https://github.com/OSC/%{package_name}/archive/v%{package_version}.ta
 # node.js packages used in the apps
 AutoReqProv:     no
 
-BuildRequires:   ondemand-runtime = %{ondemand_version}
-BuildRequires:   ondemand-scldevel = %{ondemand_version}
+BuildRequires:   ondemand-runtime = 1.5
+BuildRequires:   ondemand-scldevel = 1.5
 BuildRequires:   sqlite-devel, curl, make
-BuildRequires:   ondemand-ruby = %{ondemand_version}
-BuildRequires:   ondemand-nodejs = %{ondemand_version}
-BuildRequires:   ondemand-git = %{ondemand_version}
+BuildRequires:   ondemand-ruby = 1.5
+BuildRequires:   ondemand-nodejs = 1.5
+BuildRequires:   ondemand-git = 1.5
 Requires:        sudo, lsof, sqlite-devel, cronie, wget, curl, make
-Requires:        ondemand-apache = %{ondemand_version}
+Requires:        ondemand-apache = 1.5
 Requires:        ondemand-nginx = 1.14.0
 Requires:        ondemand-passenger = 5.3.7
-Requires:        ondemand-ruby = %{ondemand_version}
-Requires:        ondemand-nodejs = %{ondemand_version}
-Requires:        ondemand-git = %{ondemand_version}
-Requires:        ondemand-runtime = %{ondemand_version}
+Requires:        ondemand-ruby = 1.5
+Requires:        ondemand-nodejs = 1.5
+Requires:        ondemand-git = 1.5
+Requires:        ondemand-runtime = 1.5
 
 %if %{with systemd}
 BuildRequires: systemd

--- a/web/ondemand/ondemand.spec
+++ b/web/ondemand/ondemand.spec
@@ -1,8 +1,8 @@
 %{!?ncpus: %define ncpus 12}
 %global package_name ondemand
 %global major 1
-%global minor 5
-%global patch 5
+%global minor 6
+%global patch 0
 %global ondemand_version %{major}.%{minor}
 %global package_version %{major}.%{minor}.%{patch}
 %global package_release 1

--- a/web/ondemand/ondemand.spec
+++ b/web/ondemand/ondemand.spec
@@ -31,20 +31,20 @@ Source0:   https://github.com/OSC/%{package_name}/archive/v%{package_version}.ta
 # node.js packages used in the apps
 AutoReqProv:     no
 
-BuildRequires:   ondemand-runtime = 1.5
-BuildRequires:   ondemand-scldevel = 1.5
+BuildRequires:   ondemand-runtime = %{ondemand_version}
+BuildRequires:   ondemand-scldevel = %{ondemand_version}
 BuildRequires:   sqlite-devel, curl, make
-BuildRequires:   ondemand-ruby = 1.5
-BuildRequires:   ondemand-nodejs = 1.5
-BuildRequires:   ondemand-git = 1.5
+BuildRequires:   ondemand-ruby = %{ondemand_version}
+BuildRequires:   ondemand-nodejs = %{ondemand_version}
+BuildRequires:   ondemand-git = %{ondemand_version}
 Requires:        sudo, lsof, sqlite-devel, cronie, wget, curl, make
-Requires:        ondemand-apache = 1.5
+Requires:        ondemand-apache = %{ondemand_version}
 Requires:        ondemand-nginx = 1.14.0
 Requires:        ondemand-passenger = 5.3.7
-Requires:        ondemand-ruby = 1.5
-Requires:        ondemand-nodejs = 1.5
-Requires:        ondemand-git = 1.5
-Requires:        ondemand-runtime = 1.5
+Requires:        ondemand-ruby = %{ondemand_version}
+Requires:        ondemand-nodejs = %{ondemand_version}
+Requires:        ondemand-git = %{ondemand_version}
+Requires:        ondemand-runtime = %{ondemand_version}
 
 %if %{with systemd}
 BuildRequires: systemd

--- a/web/ondemand/ondemand.spec
+++ b/web/ondemand/ondemand.spec
@@ -27,6 +27,12 @@ Source0:   https://github.com/OSC/%{package_name}/archive/v%{package_version}.ta
 %bcond_with systemd
 %endif
 
+# Work around issue with EL6 builds
+# https://stackoverflow.com/a/48801417
+%if 0%{?rhel} < 7
+%define __strip /opt/rh/devtoolset-6/root/usr/bin/strip
+%endif
+
 # Disable automatic dependencies as it causes issues with bundled gems and
 # node.js packages used in the apps
 AutoReqProv:     no


### PR DESCRIPTION
After changing the spec to fix the error with 1.6 dependencies not being available the build then fails due to a failure compiling the native components of the `ffi` gem.

[root.log.gz](https://github.com/OSC/ondemand-packaging/files/3178681/root.log.gz)
