### PR TITLE
Support using mock cache inside build box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ondemand.sec
 virtualenv
 stage/*
 !stage/.keep
+docker-image/mock-cache.tar.gz

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ This only has to be done once
 
 ```
 cd docker-image
+rm mock-cache.tar.gz
+docker build -t ohiosupercomputer/ondemand_buildbox:0.0.1 .
+# update build/env
+./make-mock-cache.sh
 docker build -t ohiosupercomputer/ondemand_buildbox:0.0.1 .
 docker push ohiosupercomputer/ondemand_buildbox:0.0.1
 ```

--- a/build.sh
+++ b/build.sh
@@ -219,6 +219,10 @@ else
 fi
 
 for p in "${PACKAGES[@]}"; do
+    if [ ! -d $p -a $p != 'attach' ]; then
+        echo_red "Package ${p} is not a directory"
+        continue
+    fi
     GIT_ANNEX=false
     if which git-annex 2>/dev/null 1>/dev/null ; then
         for f in `git-annex find --include='*' ${p} 2>/dev/null`; do

--- a/build/Rakefile
+++ b/build/Rakefile
@@ -114,6 +114,7 @@ namespace :build do
       "/usr/bin/mock --verbose -r #{MOCK_CONFIG[DISTRO]}",
       GIT_TAG_DEFINE, VERSION_DEFINE, RELEASE_DEFINE,
       '--enable-network',
+      '--no-clean', '--no-cleanup-after',
       '--resultdir', WORK_DIR,
     ]
     if MOCK_ARGS

--- a/build/env
+++ b/build/env
@@ -1,1 +1,1 @@
-BUILDBOX_IMAGE='ohiosupercomputer/ondemand_buildbox:0.3.0'
+BUILDBOX_IMAGE='ohiosupercomputer/ondemand_buildbox:0.4.0'

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,5 +1,4 @@
 FROM centos:7
 MAINTAINER Trey Dockendorf <tdockendorf@osc.edu>
-
-ADD . /build
+COPY . /build
 RUN /build/install.sh

--- a/docker-image/install.sh
+++ b/docker-image/install.sh
@@ -25,7 +25,7 @@ header "Installing dependencies"
 run yum update -y
 run yum install -y epel-release centos-release-scl
 run yum install -y rubygem-rake sudo git git-annex which expect \
-    rpm-build rpmdevtools mock rpm-sign scl-utils-build docker
+    rpm-build rpmdevtools mock rpm-sign scl-utils-build
 
 header "Miscellaneous"
 run cp /build/sudoers.conf /etc/sudoers.d/ood
@@ -40,8 +40,11 @@ sudo -u ood -H cat >> /home/ood/.rpmmacros <<EOF
 EOF
 rpm --import /build/RPM-GPG-KEY-ondemand
 
-run cp /build/epel-6-x86_64.cfg /etc/mock/epel-6-x86_64.cfg
-run cp /build/epel-7-x86_64.cfg /etc/mock/epel-7-x86_64.cfg
+run cp -a /build/epel-6-x86_64.cfg /etc/mock/epel-6-x86_64.cfg
+run cp -a /build/epel-7-x86_64.cfg /etc/mock/epel-7-x86_64.cfg
+if [ -f /build/mock-cache.tar.gz ]; then
+    run tar xf /build/mock-cache.tar.gz -C /
+fi
 
 run sudo -u ood -H git config --global user.email "packages@osc.edu"
 run sudo -u ood -H git config --global user.name "OnDemand Packaging"

--- a/docker-image/make-mock-cache.sh
+++ b/docker-image/make-mock-cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/../build/env
+
+CONTAINER_ID=$(docker run \
+--detach --rm \
+--privileged \
+--cap-add=SYS_ADMIN \
+-v "${DIR}:/build:rw" \
+$BUILDBOX_IMAGE \
+/usr/sbin/init)
+
+docker exec \
+-t -i \
+-e "LC_CTYPE=en_US.UTF-8" \
+$CONTAINER_ID \
+mock -r epel-7-x86_64 --init
+
+docker exec \
+-t -i \
+-e "LC_CTYPE=en_US.UTF-8" \
+$CONTAINER_ID \
+mock -r epel-6-x86_64 --init
+
+docker exec \
+-t -i \
+-e "LC_CTYPE=en_US.UTF-8" \
+$CONTAINER_ID \
+tar czf /build/mock-cache.tar.gz /var/cache/mock
+
+docker kill $CONTAINER_ID


### PR DESCRIPTION
@ericfranz @MorganRodgers @johrstrom 

This increased the size of build box from ~600MB to ~2GB but should remove one slow part of build which is executing `yum install @buildsys-build`. We could potentially speed up builds even further by pre-installing key SCL packages into the mock cache but that would require the build box to be updated as our dependencies evolve.