### PR TITLE
Simplify repo files to not be specific to a given OS release

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If `./build.sh` had `-o /tmp/output` then the following command will upload the 
 Build release RPMs:
 
 ```
-./build.sh -w /tmp/work -o /tmp/output -S $(pwd)/misc/ondemand-release
+./build.sh -w /tmp/work -o /tmp/output -d el7 -S $(pwd)/misc/ondemand-release
 ```
 
 Release RPMs:

--- a/misc/ondemand-release/ondemand-compute.repo
+++ b/misc/ondemand-release/ondemand-compute.repo
@@ -1,13 +1,13 @@
 [ondemand-compute]
 name=Open OnDemand Compute Repo
-baseurl=https://yum.osc.edu/ondemand/1.6/compute/$DIST/$basearch/
+baseurl=https://yum.osc.edu/ondemand/1.6/compute/el$releasever/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand-compute
 
 [ondemand-compute-source]
 name=Open OnDemand Compute Repo - source
-baseurl=https://yum.osc.edu/ondemand/1.6/compute/$DIST/SRPMS/
+baseurl=https://yum.osc.edu/ondemand/1.6/compute/el$releasever/SRPMS/
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand-compute

--- a/misc/ondemand-release/ondemand-release.spec
+++ b/misc/ondemand-release/ondemand-release.spec
@@ -1,6 +1,6 @@
 Name:       ondemand-release-web
 Version:    1.6
-Release:    2%{?dist}
+Release:    2
 Summary:    Open OnDemand web repository files
 
 Group:      Applications/System

--- a/misc/ondemand-release/ondemand-release.spec
+++ b/misc/ondemand-release/ondemand-release.spec
@@ -1,6 +1,6 @@
 Name:       ondemand-release-web
 Version:    1.6
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Open OnDemand web repository files
 
 Group:      Applications/System
@@ -34,7 +34,6 @@ exit 0
 %install
 install -Dpm0644 %{SOURCE0} %{buildroot}%{_sysconfdir}/yum.repos.d/ondemand-web.repo
 install -Dpm0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/yum.repos.d/ondemand-compute.repo
-sed "s/\$DIST/$(echo %{?dist} | cut -d. -f2)/g" -i %{buildroot}%{_sysconfdir}/yum.repos.d/ondemand-*.repo
 install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-ondemand
 install -Dpm0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-ondemand-compute
 

--- a/misc/ondemand-release/ondemand-web.repo
+++ b/misc/ondemand-release/ondemand-web.repo
@@ -1,13 +1,13 @@
 [ondemand-web]
 name=Open OnDemand Web Repo
-baseurl=https://yum.osc.edu/ondemand/1.6/web/$DIST/$basearch/
+baseurl=https://yum.osc.edu/ondemand/1.6/web/el$releasever/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand
 
 [ondemand-web-source]
 name=Open OnDemand Web Repo
-baseurl=https://yum.osc.edu/ondemand/1.6/web/$DIST/SRPMS/
+baseurl=https://yum.osc.edu/ondemand/1.6/web/el$releasever/SRPMS/
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand

--- a/sync-release.py
+++ b/sync-release.py
@@ -86,6 +86,14 @@ Usage examples:
     # Prep release directories
     for t in ['compute', 'web']:
         for rel in ['el6', 'el7']:
+            rel_d = os.path.join(release_dir, t, rel)
+            if not os.path.isdir(rel_d):
+                logger.info("mkdir -p %s", rel_d)
+                os.makedirs(rel_d, 0755)
+            rel_l = "%sServer" % rel_d
+            if not os.path.islink(rel_l):
+                logger.info("ln -s %s %s", rel, rel_l)
+                os.symlink(rel, rel_l)
             for arch in ['SRPMS', 'x86_64']:
                 d = os.path.join(release_dir, t, rel, arch)
                 if not os.path.isdir(d):


### PR DESCRIPTION
@ericfranz @MorganRodgers @johrstrom 

This should make it so the install instructions for adding the OnDemand repo are not specific to RHEL6 or RHEL7.  The step would become:

```
sudo yum install https://yum.osc.edu/ondemand/1.6/ondemand-release-web-1.6-2.noarch.rpm
```

The step would be the same for RHEL6 and RHEL7. If we plan a 1.7 release then can bundle this into that release.

I've already updated the repo server to have the necessary symlinks to support this.