### PR TITLE
Update runtime to depend on rh-ruby25 and rh-nodejs10

### DIFF
--- a/web/ondemand-runtime/ondemand-runtime.spec
+++ b/web/ondemand-runtime/ondemand-runtime.spec
@@ -3,8 +3,8 @@
 %global _scl_prefix /opt/ood
 %scl_package %scl
 
-%global ruby rh-ruby24
-%global nodejs rh-nodejs6
+%global ruby rh-ruby25
+%global nodejs rh-nodejs10
 %global apache httpd24
 
 Name:      ondemand-runtime


### PR DESCRIPTION
These are not EOL and match EL8 versions. Won't affect anything until ondemand package is bumped to 1.7.x