### PR TITLE
Set GEM_HOME and GEM_PATH when ondemand SCL is loaded

### DIFF
--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -43,7 +43,7 @@ ondemand-runtime:
     - ondemand-runtime
     - ondemand-scldevel
   versions:
-    - 1.7-2
+    - 1.7-3
 ondemand:
   - 1.6.7-1
 

--- a/web/ondemand-runtime/ondemand-runtime.spec
+++ b/web/ondemand-runtime/ondemand-runtime.spec
@@ -14,10 +14,11 @@
 %global nodejs rh-nodejs10
 %global apache httpd24
 %endif
+%global ruby_version 2.5
 
 Name:      ondemand-runtime
 Version:   1.7
-Release:   2%{?dist}
+Release:   3%{?dist}
 Summary:   Package that handles %{scl} Software Collection.
 License:   MIT
 
@@ -121,6 +122,8 @@ export LD_LIBRARY_PATH="%{_libdir}\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}"
 export MANPATH="%{_mandir}:\${MANPATH:-}"
 export PKG_CONFIG_PATH="%{_libdir}/pkgconfig\${PKG_CONFIG_PATH:+:\${PKG_CONFIG_PATH}}"
 export RUBYLIB="%{_datadir}/ruby/vendor_ruby:%{_libdir}/ruby/vendor_ruby\${RUBYLIB:+:\${RUBYLIB}}"
+export GEM_HOME="%{_datadir}/gems/%{ruby_version}"
+export GEM_PATH="\${GEM_HOME}:\${GEM_PATH}"
 EOF
 
 cat >> %{buildroot}%{_root_sysconfdir}/rpm/macros.%{scl_name_base}-scldevel << EOF

--- a/web/ondemand-runtime/ondemand-runtime.spec
+++ b/web/ondemand-runtime/ondemand-runtime.spec
@@ -137,6 +137,7 @@ cat >> %{buildroot}%{_root_sysconfdir}/rpm/macros.%{scl_name_base}-scldevel << E
 %%scl_%{scl_name_base}_prefix_nodejs %{nodejs}-
 %%scl_%{scl_name_base}_apache %{apache}
 %%scl_%{scl_name_base}_prefix_apache %{apache}-
+%%scl_%{scl_name_base}_gem_home %{_datadir}/gems/%{ruby_version}
 %endif
 EOF
 


### PR DESCRIPTION
This is needed to support using a single Gemfile with ondemand that doesn't have to use `--path` during `bundle install`.