### PR TITLE
Add ondemand-passenger-status wrapper script

### DIFF
--- a/packages/passenger/passenger.spec
+++ b/packages/passenger/passenger.spec
@@ -24,7 +24,7 @@
 
 Name:       %{?scl_prefix}passenger
 Version:    %{passenger_version}
-Release:    2%{?dist}
+Release:    3%{?dist}
 Summary:    Phusion Passenger application server
 URL:        https://www.phusionpassenger.com
 Group:      System Environment/Daemons
@@ -81,7 +81,7 @@ This package contains documentation files for Phusion Passenger®.
 Summary: A high performance web server and reverse proxy server
 URL:        http://nginx.org/
 Version: %{nginx_version}
-Release: 2.p%{passenger_version}%{?dist}
+Release: 3.p%{passenger_version}%{?dist}
 Obsoletes: %{?scl_prefix}nginx-filesystem
 BuildRequires: libxslt-devel
 BuildRequires: gd-devel
@@ -253,6 +253,16 @@ popd
 
 # Don't need Apache module
 %{__rm} -f %{buildroot}%{_httpd_moddir}/mod_passenger.so
+
+# Add passenger-status wrapper
+%{__mkdir_p} %{buildroot}%{_root_prefix}/local/sbin
+%{__cat} > %{buildroot}%{_root_prefix}/local/sbin/ondemand-passenger-status <<'EOS'
+#!/bin/bash
+
+. scl_source enable ondemand
+
+%{_sbindir}/passenger-status "$@"
+EOS
 EOF
 
 %pre -n %{?scl_prefix}nginx
@@ -286,6 +296,7 @@ fi
 %{_datadir}/passenger/*.p12
 %{passenger_ruby_libdir}/*
 %{ruby_vendorarchdir}/passenger_native_support.so
+%{_root_prefix}/local/sbin/ondemand-passenger-status
 
 %files doc
 %{_docdir}/passenger/*

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -28,7 +28,7 @@ ondemand-nginx:
     - ondemand-nginx
     - ondemand-nginx-debuginfo
   versions:
-    - 1.17.3-2.p6.0.4
+    - 1.17.3-3.p6.0.4
 ondemand-passenger:
   packages:
     - ondemand-passenger
@@ -36,7 +36,7 @@ ondemand-passenger:
     - ondemand-passenger-devel
     - ondemand-passenger-doc
   versions:
-    - 6.0.4-2
+    - 6.0.4-3
 ondemand-runtime:
   packages:
     - ondemand-apache


### PR DESCRIPTION
Need this wrapper script to more easily execute `passenger-status` with sudo for monitoring.