### PR TITLE
initial commit to make this repo a gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ stage/*
 !stage/.keep
 docker-image/mock-cache.tar.gz
 .venv/
+
+pkg/
+build/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+# style
+Style/MultilineBlockChain:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: 'no_mixed_keys'
+Style/ClassAndModuleChildren:
+  EnforcedStyle: 'compact'
+Style/WordArray:
+  EnforcedStyle: 'brackets'
+Style/SymbolArray:
+  EnforcedStyle: 'brackets'
+
+# layout
+Layout/HashAlignment:
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in ood_core.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require "bundler/gem_tasks"
+
+task :default => :build
+
+TASK_DIR = "#{__dir__}/lib/tasks"
+
+require "#{TASK_DIR}/packaging"

--- a/lib/ood_packaging/version.rb
+++ b/lib/ood_packaging/version.rb
@@ -1,0 +1,3 @@
+module OodPackaging
+  VERSION = "0.0.1"
+end

--- a/lib/tasks/package_utils.rb
+++ b/lib/tasks/package_utils.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'erb'
+require 'tempfile'
+
+module PackageUtils
+  def version
+    @version ||= if !ENV['VERSION']
+                   tag? ? git_tag : "#{git_tag}-#{git_hash}"
+                 else
+                   ENV['VERSION'].to_s
+                 end
+  end
+
+  def build_timestamp
+    @build_timestamp ||= Time.now.strftime('%s')
+  end
+
+  def git_hash
+    @git_hash ||= `git rev-parse HEAD`.strip[0..6]
+  end
+
+  def git_tag
+    @git_tag ||= `git describe --tags --abbrev=0`.chomp
+  end
+
+  def numeric_tag
+    @numeric_tag ||= git_tag.delete_prefix('v')
+  end
+
+  def tag?
+    @tag ||= `git describe --exact-match --tags HEAD 2>/dev/null`.to_s != ''
+  end
+
+  def podman_runtime?
+    @podman_runtime ||= ENV['CONTAINER_RT'] == 'podman'
+  end
+
+  def docker_runtime?
+    !podman_runtime?
+  end
+
+  def container_runtime
+    podman_runtime? ? 'podman' : 'docker'
+  end
+
+  def tar
+    @tar ||= begin
+      `which gtar 1>/dev/null 2>&1`
+      $CHILD_STATUS.success? ? 'gtar' : 'tar'
+    end
+  end
+
+  def src_dir
+    ENV['OOD_SRC_DIR'] || '.'
+  end
+
+  def user
+    @user ||= Etc.getpwnam(Etc.getlogin)
+  end
+
+  def build_dir(args)
+    @build_dir ||= "#{src_dir}/build/#{build_box_image(args).gsub(':', '-')}".tap { |d| sh "mkdir -p #{d}" }
+  end
+
+  # TODO: continue vendor/ convention? Seems as good as any other name.
+  def vendor_src_dir
+    'vendor/ood/src'.tap { |p| sh "mkdir -p #{p}" }
+  end
+
+  def vendor_build_dir
+    'vendor/ood/build'.tap { |p| sh "mkdir -p #{p}" }
+  end
+
+  def dist_dir(args)
+    dist = args[:dist].to_s
+    version = args[:version].to_s
+
+    if dist == 'el'
+      "dist/#{dist}#{version}"
+    else
+      # don't know what the debian format should be
+      "dist/#{dist}#{version}"
+    end
+  end
+
+  def known_images
+    {
+      'ubuntu-20.04': '1'
+    }.freeze
+  end
+
+  def build_box_image(args)
+    base_name = "#{args[:dist]}-#{args[:version]}"
+    @version_lookup ||= Hash.new('1').merge(known_images)
+
+    "#{build_box_name}:#{base_name}-#{@version_lookup[base_name.to_sym]}"
+  end
+
+  def build_box_name
+    ENV['OOD_BUILD_BOX'] || 'ood-buildbox'
+  end
+
+  def image_exists?(image_name)
+    `#{container_runtime} inspect --type image --format exists #{image_name} || true`.chomp.eql?('exists')
+  end
+
+  def build_cmd(file, image)
+    args = [container_runtime, 'build', '-t', image, '-f', file]
+    args.concat '.' if docker_runtime?
+    args.join(' ')
+  end
+
+  def template_file(filename)
+    cwd = File.expand_path(__dir__).to_s
+    content = File.read("#{cwd}/templates/#{filename}")
+    content = ERB.new(content, nil, '-').result(binding)
+
+    begin
+      t = Tempfile.new('ood-docker')
+      t.write(content)
+      t.path
+    ensure
+      t.close
+    end
+  end
+
+  def ctr_home
+    "/home/#{ctr_user}"
+  end
+
+  def ctr_user
+    'ood'
+  end
+
+  def ctr_run_args
+    [
+      '--rm', '--user', "#{ctr_user}:#{ctr_user}",
+      '-e', 'LC_CTYPE=en_US.UTF-8'
+    ].concat(rt_specific_flags)
+  end
+
+  def rt_specific_flags
+    if podman_runtime?
+      # SELinux doesn't like it if you're mounting from $HOME
+      ['--security-opt', 'label=disable', '--userns=keep-id']
+    else
+      []
+    end
+  end
+
+  def arch
+    'x86_64'
+  end
+
+  def spec_location
+    sf = Dir.glob('packaging/rpm/*.spec').first
+    raise StandardError, 'Cannot find spec file in packaging/rpm' if sf.nil?
+
+    sf
+  end
+
+  def spec_file
+    File.basename(spec_location)
+  end
+
+  def rpm_build_args
+    [git_tag_define, version_define, '-ba', '--nodeps', '-vv', spec_file]
+
+    # if git_prerelease_tag.size >= 2
+    #   git_prerelease_verison = git_prerelease_tag[0]
+    #   git_prerelease_verison = git_prerelease_verison[1..-1] if git_prerelease_verison.start_with?('v')
+    #   version_define = "--define 'package_version #{git_prerelease_verison}'"
+    #   if git_tag.size >= 2
+    #     prerelease = git_prerelease_tag[1].gsub('-', '.')
+    #     release_define = "--define 'package_release 0.#{prerelease}'"
+    #   else
+    #     release_define = "--define 'package_release 0.#{git_prerelease_tag[1]}.1'"
+    #   end
+    # else
+    #   version_define = "--define 'package_version #{git_tag_version}'"
+    #   release_define = if git_tag.size >= 2
+    #                      "--define 'package_release #{git_tag[1]}'"
+    #                    else
+    #                      ''
+    #                    end
+    # end
+  end
+
+  def version_define
+    git_tag = version.split('-')
+    git_tag_version = git_tag[0]
+    git_tag_version = git_tag_version[1..-1] if git_tag_version.start_with?('v')
+
+    "--define 'package_version #{git_tag_version}'"
+  end
+
+  def git_tag_define
+    "--define 'git_tag #{version}'"
+  end
+end

--- a/lib/tasks/packaging.rb
+++ b/lib/tasks/packaging.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+desc 'Package OnDemand'
+namespace :package do
+  require_relative 'package_utils'
+  include PackageUtils
+
+  desc 'Tar and zip OnDemand into packaging dir with version name v#<version>'
+  task :tar, [:output_dir] do |_task, args|
+    version = ENV['VERSION'] || ENV['CI_COMMIT_TAG']
+    version = version.gsub(/^v/, '') unless version.nil?
+
+    chdir src_dir do
+      unless version
+        latest_commit = `git rev-list --tags --max-count=1`.strip[0..6]
+        latest_tag = `git describe --tags #{latest_commit}`.strip[1..-1]
+        datetime = Time.now.strftime('%Y%m%d-%H%M')
+        version = "#{latest_tag}-#{datetime}-#{latest_commit}"
+      end
+
+      dir = (args[:output_dir] || 'packaging/rpm').to_s.tap { |p| sh "mkdir -p #{p}" }
+      sh "git ls-files | #{tar} -c --transform 's,^,ondemand-#{version}/,' -T - | gzip > #{dir}/v#{version}.tar.gz"
+    end
+  end
+
+  # TODO: refactor these 2 tar tasks. Debian and RHEL expect slightly different names and
+  # what's worse is the whole v prefixing mess
+  task :debian_tar, [:output_dir] do |_task, args|
+    dir = (args[:output_dir] || 'packaging').to_s.tap { |p| sh "mkdir -p #{p}" }
+    tar_file = "#{dir}/#{ood_package_tar}"
+
+    sh "rm #{tar_file}" if File.exist?(tar_file)
+    sh "git ls-files | #{tar} -c --transform 's,^,#{versioned_ood_package}/,' -T - | gzip > #{tar_file}"
+  end
+
+  task :version do
+    puts package_version
+  end
+
+  task :deb, [:dist, :version] => [:build_box] do |_task, args|
+    dir = build_dir(args)
+    Rake::Task['package:debian_tar'].invoke(dir)
+    sh "#{tar} -xzf #{dir}/#{ood_package_tar} -C #{dir}"
+
+    work_dir = "/build/#{versioned_ood_package}"
+
+    base_args = ctr_run_args
+    base_args.concat ['-v', "#{dir}:/build", '-w', work_dir.to_s]
+    base_args.concat ['-e', "DEBUILD_DPKG_BUILDPACKAGE_OPTS='-us -uc -I -i'"]
+    base_args.concat ['-e', 'HOME=/home/ood', '-e', 'USER=ood']
+    base_args.concat ['-e', "VERSION=#{ENV['VERSION']}"] unless ENV['VERSION'].nil?
+    base_args.concat [build_box_image(args)]
+    sh "#{container_runtime} run #{base_args.join(' ')} debmake -b':ruby'"
+
+    debuild_args = ['debuild', '--no-lintian']
+    sh "#{container_runtime} run #{base_args.join(' ')} #{debuild_args.join(' ')}"
+  end
+
+  task :bootstrap_rpm, [:dist, :version] => [:verify_args] do |_task, args|
+    chdir src_dir do
+      build_dir(args).tap do |d|
+        src_dir = "#{d}/rpmbuild/SOURCES".tap { |s| sh "mkdir -p #{s}" }
+        dist_dir(args).tap { |dd| sh "mkdir -p #{dd}" }
+        Rake::Task['package:tar'].invoke(src_dir)
+
+        FileUtils.cp Dir.glob('packaging/rpm/*.{fc,te,ico,png,tar.gz}'), src_dir
+        FileUtils.cp spec_location, d
+      end
+    end
+  end
+
+  desc 'Build an RPM'
+  task :rpm, [:dist, :version] => [:build_box, :bootstrap_rpm] do |_task, args|
+    dir = build_dir(args)
+    image = build_box_image(args)
+
+    base_args = ctr_run_args
+    base_args.concat ['-v', "#{dir}:#{ctr_home}", '-w', "'#{ctr_home}'"]
+    base_args.concat ['-e', "HOME=#{ctr_home}"]
+
+    chdir src_dir do
+      sh "#{container_runtime} run #{base_args.join(' ')} #{image} rpmbuild #{rpm_build_args.join(' ')}"
+      FileUtils.cp Dir.glob("#{dir}/rpmbuild/RPMS/#{arch}/*.rpm"), dist_dir(args)
+    end
+  end
+
+  namespace :rpm do
+    desc 'Build nightly RPM'
+    task :nightly, [:dist, :extra_args] do |_task, args|
+      version_major, version_minor, version_patch = git_tag.gsub(/^v/, '').split('.', 3)
+      date = Time.now.strftime('%Y%m%d')
+      id = ENV['CI_PIPELINE_ID'] || Time.now.strftime('%H%M%S')
+      ENV['VERSION'] = "#{version_major}.#{version_minor}.#{date}-#{id}.#{git_hash}.nightly"
+      Rake::Task['package:rpm'].invoke(args[:dist], args[:extra_args])
+    end
+  end
+
+  task :verify_args, [:dist, :version] do |_task, args|
+    raise 'Need to specify :dist and :version' if args[:dist].nil? || args[:version].nil?
+  end
+
+  desc 'Create buildbox for Open OnDemand'
+  task :build_box, [:dist, :version] => [:verify_args] do |_task, args|
+    cmd = build_cmd(
+      template_file("Dockerfile.#{args[:dist]}.erb"),
+      build_box_image(args)
+    )
+
+    sh cmd unless image_exists?(build_box_image(args))
+  end
+end

--- a/lib/tasks/templates/Dockerfile.el.erb
+++ b/lib/tasks/templates/Dockerfile.el.erb
@@ -1,0 +1,21 @@
+FROM centos:8
+
+# install all the dependencies
+RUN dnf -y update 
+RUN dnf install -y dnf-utils 
+RUN dnf config-manager --set-enabled powertools
+RUN dnf -y module enable nodejs:12 ruby:2.7
+RUN dnf install -y \
+        make gcc gcc-c++ git rsync rpm-build redhat-rpm-config
+RUN dnf install -y libselinux libselinux-devel
+RUN dnf install -y selinux-policy selinux-policy-devel
+RUN dnf install -y scl-utils
+
+RUN dnf install -y https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm
+RUN dnf install -y \
+        ondemand-runtime ondemand-scldevel ondemand-build ondemand-ruby ondemand-python ondemand-nodejs 
+
+RUN dnf clean all && rm -rf /var/cache/dnf/*
+
+RUN groupadd <%= ctr_user %> && \
+    useradd --create-home --gid <%= ctr_user %> <%= ctr_user %>

--- a/lib/tasks/templates/Dockerfile.ubuntu.erb
+++ b/lib/tasks/templates/Dockerfile.ubuntu.erb
@@ -1,0 +1,15 @@
+from ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+  apt install -y \
+    ruby=1:2.7+1 ruby-dev=1:2.7+1 \
+    nodejs npm \
+    make g++ gcc sqlite3 libsqlite3-dev \
+    debmake debhelper
+
+RUN groupadd <%= ctr_user %> && \
+    useradd --create-home --gid <%= ctr_user %> <%= ctr_user %>
+
+RUN ln -s /bin/bundle2.7 /bin/bundle

--- a/ood-packaging.gemspec
+++ b/ood-packaging.gemspec
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'ood_packaging/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'ood_packaging'
+  spec.version       = OodPackaging::VERSION
+  spec.authors       = ['Trey Dockendorf', 'Jeff Ohrstrom']
+  spec.email         = ['tdockendorf@osc.edu', 'johrstrom@osc.edu']
+
+  spec.summary       = 'Open OnDemand packaging library'
+  spec.description   = 'Open OnDemand packaging library provides Rake tasks like package:rpm and pacakge:deb'
+  spec.homepage      = 'https://github.com/OSC/ood-packaging'
+  spec.license       = 'MIT'
+
+  spec.files         = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r{^lib/})
+  end
+  spec.bindir        = 'bin'
+  spec.executables   = []
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.2.0'
+
+  spec.add_runtime_dependency 'rake', '~> 13.0.1'
+end

--- a/ood-packaging.gemspec
+++ b/ood-packaging.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Open OnDemand packaging library'
   spec.description   = 'Open OnDemand packaging library provides Rake tasks like package:rpm and pacakge:deb'
-  spec.homepage      = 'https://github.com/OSC/ood-packaging'
+  spec.homepage      = 'https://github.com/OSC/ondemand-packaging'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
This work starts to package this functionality in a gem.  The idea here is to simplify our build system to support debian and rpm packaging in a single coherent way.

Distributed as rake tasks one could load it in a ruby project and build their PRMs or someone could get the gem and we have an `ondemand-packaging` that shows up in your PATH.

Still lots to do. This came about because I needed an rpm and things didn't work with podman/debian systems. I didn't test Debian builds, just copied it.