### PR TITLE
Debian packaging improvements

### DIFF
--- a/build/Rakefile
+++ b/build/Rakefile
@@ -302,20 +302,21 @@ namespace :deb do
       sh "mkdir -p #{WORK_DIR}"
     end
     sh "cp -a #{BUILD_DIR}/* #{WORK_DIR}/"
+    puts "\tExtract source".blue
     Dir.chdir(WORK_DIR) do
-      sh "ln -snf #{DEB_NAME}.tar.gz #{PACKAGE_NAME}_#{VERSION}.orig.tar.gz"
       sh "tar -xf #{DEB_NAME}.tar.gz"
     end
+    puts "\tBootstrap debian build files".blue
     Dir.chdir(File.join(WORK_DIR, DEB_NAME)) do
+      sh "dh_make -s -y --createorig -f ../#{DEB_NAME}.tar.gz #{cmd_suffix} || true"
       sh "dch -b -v #{VERSION} 'Release #{VERSION}' #{cmd_suffix}"
     end
     puts "\tUpdating packages".blue
     sh "sudo apt-get update #{cmd_suffix}"
     sh "sudo apt upgrade -y #{cmd_suffix}"
     puts "\tInstalling dependencies".blue
-    config = packaging_config(File.join(WORK_DIR, DEB_NAME, 'debian/packaging.yaml'))
-    if config['dependencies']
-      sh "sudo apt install -y #{config['dependencies'].join(' ')} #{cmd_suffix}"
+    Dir.chdir(File.join(WORK_DIR, DEB_NAME)) do
+      sh "mk-build-deps --install --remove --root-cmd sudo --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' #{cmd_suffix}"
     end
   end
   desc "Build deb package"

--- a/docker-image/env
+++ b/docker-image/env
@@ -1,3 +1,3 @@
 BUILDBOX_IMAGE='ohiosupercomputer/ondemand_buildbox:3.2.0'
-DEB_BUILDBOX_IMAGE=ohiosupercomputer/ondemand_buildbox-$DIST-$DISTVERSION:0.1.0
+DEB_BUILDBOX_IMAGE=ohiosupercomputer/ondemand_buildbox-$DIST-$DISTVERSION:0.2.0
 MOCK_CACHE=$(echo "mock-cache-${BUILDBOX_IMAGE}.tar.gz" | sed 's#/#_#g' | sed 's#:#_#g')

--- a/docker-image/install.sh
+++ b/docker-image/install.sh
@@ -22,7 +22,7 @@ source /etc/os-release
 header "Installing dependencies"
 if [[ "$ID_LIKE" == *debian* ]]; then
 	run apt-get update -y
-	run apt install -y init debhelper devscripts build-essential lintian \
+	run apt install -y init debhelper devscripts dh-make build-essential lintian equivs \
 			sudo python rake wget curl ruby
 	run ln -snf /bin/bundle2.7 /bin/bundle
 else


### PR DESCRIPTION
Use Debian helper command to generate orig.tar.gz which should make various different kinds of versions work better (Fixes #139)

Auto install Debian build dependencies (Fixes #138)