### PR TITLE
Release script refactor

### DIFF
--- a/release.ini
+++ b/release.ini
@@ -3,6 +3,7 @@ host = repo.hpc.osc.edu
 rpm_path = /var/www/repos/public/ondemand/latest/web/DIST/x86_64/
 srpm_path = /var/www/repos/public/ondemand/latest/web/DIST/SRPMS/
 deb_path = /var/www/repos/public/ondemand/latest/web/apt
+release = latest
 update = yes
 # Use these values for testing
 #rpm_path = /tmp/DIST/x86_64
@@ -12,6 +13,7 @@ host = repo.hpc.osc.edu
 rpm_path = /var/www/repos/public/ondemand/ci/web/DIST/x86_64/
 srpm_path = /var/www/repos/public/ondemand/ci/web/DIST/SRPMS/
 deb_path = /var/www/repos/public/ondemand/ci/web/apt
+release = ci
 update = yes
 # Use these values for testing
 #rpm_path = /tmp/DIST/x86_64
@@ -20,6 +22,7 @@ update = yes
 rpm_path = /var/www/repos/public/ondemand/latest/
 srpm_path = /var/www/repos/public/ondemand/latest/
 deb_path = /var/www/repos/public/ondemand/latest/
+release = latest
 update = no
 # Use these values for testing
 #rpm_path = /tmp/release
@@ -29,6 +32,7 @@ host = repo.hpc.osc.edu
 rpm_path = /var/www/repos/public/ondemand/build/RELEASE/web/DIST/x86_64/
 srpm_path = /var/www/repos/public/ondemand/build/RELEASE/web/DIST/SRPMS/
 deb_path = /var/www/repos/public/ondemand/build/RELEASE/web/apt
+release = build/RELEASE
 update = yes
 # Use these values for testing
 #rpm_path = /tmp/DIST/x86_64
@@ -38,6 +42,7 @@ host = repo.hpc.osc.edu
 rpm_path = /var/www/repos/public/ondemand/nightly/RELEASE/web/DIST/x86_64/
 srpm_path = /var/www/repos/public/ondemand/nightly/RELEASE/web/DIST/SRPMS/
 deb_path = /var/www/repos/public/ondemand/nightly/RELEASE/web/apt
+release = nightly
 update = yes
 # Use these values for testing
 #rpm_path = /tmp/DIST/x86_64

--- a/release.py
+++ b/release.py
@@ -20,6 +20,7 @@ logger = logging.getLogger()
 deb_dist_map = {
     'ubuntu-20.04': 'focal',
 }
+PROJ_ROOT = os.path.dirname(os.path.realpath(__file__))
 
 def release_packages(packages, host, path, pkey, force):
     uploads = False
@@ -43,154 +44,27 @@ def release_packages(packages, host, path, pkey, force):
     ssh.close()
     return uploads
 
-def update_repo(host, path, pkey, gpgpass):
+def update_repo(host, release, dist, pkey):
     _pkey = paramiko.RSAKey.from_private_key_file(pkey)
-    createrepo_cmd = "cd %s ; createrepo_c --update ." % path
-    gpg_cmd = "cd %s ; gpg --detach-sign --passphrase-file %s --batch --yes --no-tty --armor repodata/repomd.xml" % (path, gpgpass)
-    logger.info("Updating repo metadata at %s:%s", host, path)
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, createrepo_cmd)
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(hostname=host, username='oodpkg', password=None, pkey=_pkey)
-    createrepo_stdin, createrepo_stdout, createrepo_stderr = ssh.exec_command(createrepo_cmd)
-    createrepo_out = createrepo_stdout.read()
-    createrepo_err = createrepo_stderr.read()
-    logger.debug("SSH CMD STDOUT:\n%s", createrepo_out)
-    logger.debug("SSH CMD STDERR:\n%s", createrepo_err)
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, gpg_cmd)
-    gpg_stdin, gpg_stdout, gpg_stderr = ssh.exec_command(gpg_cmd)
-    gpg_out = gpg_stdout.read()
-    gpg_err = gpg_stderr.read()
-    logger.debug("SSH CMD STDOUT:\n%s", gpg_out)
-    logger.debug("SSH CMD STDERR:\n%s", gpg_err)
-    ssh.close()
-
-def update_apt_repo(host, path, dist, release, pkey, gpgpass):
-    dist_path = os.path.join(path, 'dists', dist)
-    _pkey = paramiko.RSAKey.from_private_key_file(pkey)
-    dpkg_scanpackages_cmd = "cd %s ; dpkg-scanpackages --arch amd64 pool/%s > dists/%s/main/binary-amd64/Packages" % (path, dist, dist)
-    dpkg_gzip_packages_cmd = "cd %s ; cat dists/%s/main/binary-amd64/Packages | gzip -9 > dists/%s/main/binary-amd64/Packages.gz" % (path, dist, dist)
-    logger.info("Updating repo Packages at %s:%s", host, path)
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, dpkg_scanpackages_cmd)
-    ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh.connect(hostname=host, username='oodpkg', password=None, pkey=_pkey)
-    dpkg_scanpackages_stdin, dpkg_scanpackages_stdout, dpkg_scanpackages_stderr = ssh.exec_command(dpkg_scanpackages_cmd)
-    dpkg_scanpackages_out = dpkg_scanpackages_stdout.read()
-    dpkg_scanpackages_err = dpkg_scanpackages_stderr.read()
-    logger.debug("SSH CMD STDOUT:\n%s", dpkg_scanpackages_out)
-    logger.debug("SSH CMD STDERR:\n%s", dpkg_scanpackages_err)
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, dpkg_gzip_packages_cmd)
-    dpkg_gzip_packages_stdin, dpkg_gzip_packages_stdout, dpkg_gzip_packages_stderr = ssh.exec_command(dpkg_gzip_packages_cmd)
-    dpkg_gzip_packages_out = dpkg_gzip_packages_stdout.read()
-    dpkg_gzip_packages_err = dpkg_gzip_packages_stderr.read()
-    logger.debug("SSH CMD STDOUT:\n%s", dpkg_gzip_packages_out)
-    logger.debug("SSH CMD STDERR:\n%s", dpkg_gzip_packages_err)
-    md5sum_cmd = "cd %s ; md5sum main/binary-amd64/Packages*" % dist_path
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, md5sum_cmd)
-    md5sum_stdin, md5sum_stdout, md5sum_stderr = ssh.exec_command(md5sum_cmd)
-    md5sum_out = md5sum_stdout.read().decode('ascii')
-    md5sum_err = md5sum_stderr.read().decode('ascii')
-    logger.debug("SSH CMD STDOUT:\n%s", md5sum_out)
-    logger.debug("SSH CMD STDERR:\n%s", md5sum_err)
-    sha1sum_cmd = "cd %s ; sha1sum main/binary-amd64/Packages*" % dist_path
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, sha1sum_cmd)
-    sha1sum_stdin, sha1sum_stdout, sha1sum_stderr = ssh.exec_command(sha1sum_cmd)
-    sha1sum_out = sha1sum_stdout.read().decode('ascii')
-    sha1sum_err = sha1sum_stderr.read().decode('ascii')
-    logger.debug("SSH CMD STDOUT:\n%s", sha1sum_out)
-    logger.debug("SSH CMD STDERR:\n%s", sha1sum_err)
-    sha256sum_cmd = "cd %s ; sha256sum main/binary-amd64/Packages*" % dist_path
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, sha256sum_cmd)
-    sha256sum_stdin, sha256sum_stdout, sha256sum_stderr = ssh.exec_command(sha256sum_cmd)
-    sha256sum_out = sha256sum_stdout.read().decode('ascii')
-    sha256sum_err = sha256sum_stderr.read().decode('ascii')
-    logger.debug("SSH CMD STDOUT:\n%s", sha256sum_out)
-    logger.debug("SSH CMD STDERR:\n%s", sha256sum_err)
-    wc_cmd = "cd %s ; wc -c main/binary-amd64/Packages*" % dist_path
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, wc_cmd)
-    wc_stdin, wc_stdout, wc_stderr = ssh.exec_command(wc_cmd)
-    wc_out = wc_stdout.read().decode('ascii')
-    wc_err = wc_stderr.read().decode('ascii')
-    logger.debug("SSH CMD STDOUT:\n%s", wc_out)
-    logger.debug("SSH CMD STDERR:\n%s", wc_err)
-    utcnow = datetime.datetime.utcnow()
-    date = utcnow.strftime("%a, %d %b %Y %H:%M:%S +0000")
-    sizes = {}
-    for line in wc_out.splitlines():
-        items = line.strip().split(' ')
-        if len(items) != 2:
-            continue
-        sizes[items[1]] = items[0]
-    md5sums = []
-    sha1sums = []
-    sha256sums = []
-    for line in md5sum_out.splitlines():
-        items = line.strip().split()
-        if len(items) != 2:
-            continue
-        if items[1] not in sizes:
-            continue
-        md5sums.append(" %s %s %s" % (items[0], sizes[items[1]], items[1]))
-    for line in sha1sum_out.splitlines():
-        items = line.strip().split()
-        if len(items) != 2:
-            continue
-        if items[1] not in sizes:
-            continue
-        sha1sums.append(" %s %s %s" % (items[0], sizes[items[1]], items[1]))
-    for line in sha256sum_out.splitlines():
-        items = line.strip().split()
-        if len(items) != 2:
-            continue
-        if items[1] not in sizes:
-            continue
-        sha256sums.append(" %s %s %s" % (items[0], sizes[items[1]], items[1]))
-    release = """
-Origin: OnDemand Repository
-Label: OnDemand
-Suite: stable
-Codename: {dist}
-Version: {release}
-Architectures: amd64
-Components: main
-Description: OnDemand repository
-Date: {date}
-MD5Sum:
-{md5sums}
-SHA1:
-{sha1sums}
-SHA256:
-{sha256sums}
-""".format(dist=dist, release=release, date=date, md5sums="\n".join(md5sums), sha1sums="\n".join(sha1sums), sha256sums="\n".join(sha256sums))
-    release_path = os.path.join(dist_path, 'Release')
-    release_tmp = tempfile.NamedTemporaryFile(delete=False, mode='w')
-    release_tmp.write(release)
-    release_tmp.close()
     sftp = ssh.open_sftp()
-    logger.debug("SFTP %s -> oodpkg@%s:%s", release_tmp.name, host, release_path)
-    logger.info("Create Release at %s", release_path)
-    sftp.put(release_tmp.name, release_path)
-    gpg_cmd = "cd %s ; cat Release | gpg --detach-sign --passphrase-file %s --batch --yes --no-tty --digest-algo SHA256 --cert-digest-algo SHA256 --armor > Release.gpg" % (dist_path, gpgpass)
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, gpg_cmd)
-    gpg_stdin, gpg_stdout, gpg_stderr = ssh.exec_command(gpg_cmd)
-    gpg_out = gpg_stdout.read()
-    gpg_err = gpg_stderr.read()
-    logger.debug("SSH CMD STDOUT:\n%s", gpg_out)
-    logger.debug("SSH CMD STDERR:\n%s", gpg_err)
-    gpg_clearsign_cmd = "cd %s ; cat Release | gpg --detach-sign --passphrase-file %s --batch --yes --no-tty --armor --digest-algo SHA256 --cert-digest-algo SHA256 --clearsign > InRelease" % (dist_path, gpgpass)
-    logger.debug("Executing via SSH oodpkg@%s '%s'", host, gpg_clearsign_cmd)
-    gpg_clearsign_stdin, gpg_clearsign_stdout, gpg_clearsign_stderr = ssh.exec_command(gpg_clearsign_cmd)
-    gpg_clearsign_out = gpg_clearsign_stdout.read()
-    gpg_clearsign_err = gpg_clearsign_stderr.read()
-    logger.debug("SSH CMD STDOUT:\n%s", gpg_clearsign_out)
-    logger.debug("SSH CMD STDERR:\n%s", gpg_clearsign_err)
+    repo_update_src = os.path.join(PROJ_ROOT, 'repo-update.sh')
+    repo_update_dest = '/var/lib/oodpkg/repo-update.sh'
+    logger.info("SFTP %s -> oodpkg@%s:%s", repo_update_src, host, repo_update_dest)
+    sftp.put(repo_update_src, repo_update_dest)
+    repo_update_cmd = "/bin/bash %s -r %s -d %s" % (repo_update_dest, release, dist)
+    logger.info("Executing via SSH oodpkg@%s '%s'", host, repo_update_cmd)
+    stdin, stdout, stderr = ssh.exec_command(repo_update_cmd)
+    out = stdout.read()
+    err = stderr.read()
+    logger.debug("SSH CMD STDOUT:\n%s", out)
+    logger.debug("SSH CMD STDERR:\n%s", err)
     ssh.close()
-    os.unlink(release_tmp.name)
 
 def main():
     pkey = os.path.expanduser('~/.ssh/id_rsa')
-    gpgpass = '/systems/osc_certs/gpg/ondemand/.gpgpass'
     usage_examples = """
 Usage examples:
 
@@ -202,7 +76,6 @@ Usage examples:
     parser.add_argument('-d', '--debug', action='store_true', default=False)
     parser.add_argument('-f', '--force', help='overwrite existing RPMs', action='store_true', default=False)
     parser.add_argument('--pkey', help='SSH private key to use for uploading RPMs (default: %(default)s)', default=pkey)
-    parser.add_argument('-g','--gpgpass', help='GPG passphrase file (default: %(default)s)', default=gpgpass)
     parser.add_argument('-c', '--config-section', help='config section to use', default='main')
     parser.add_argument('-r', '--release', help='Build repo release to use', default=None)
     parser.add_argument('dirs', nargs='+')
@@ -235,6 +108,7 @@ Usage examples:
     config.read(config_path)
     host = config.get('main', 'host')
     update = config.getboolean(args.config_section, 'update')
+    release = config.get(args.config_section, 'release').replace('RELEASE', build_release)
 
     for release_dir in args.dirs:
         dist = os.path.basename(release_dir)
@@ -255,7 +129,7 @@ Usage examples:
                     debs.append(p)
             debs_released = release_packages(debs, host, pool_path, args.pkey, args.force)
             if debs_released and update:
-                update_apt_repo(host, deb_basepath, deb, args.config_section, args.pkey, args.gpgpass)
+                update_repo(host, release, deb, args.pkey)
         else:
             rpm_path = config.get(args.config_section, 'rpm_path').replace('DIST', dist).replace('RELEASE', build_release)
             srpm_path = config.get(args.config_section, 'srpm_path').replace('DIST', dist).replace('RELEASE', build_release)
@@ -273,9 +147,9 @@ Usage examples:
             rpms_released = release_packages(rpms, host, rpm_path, args.pkey, args.force)
             srpms_released = release_packages(srpms, host, srpm_path, args.pkey, args.force)
             if rpms_released and update:
-                update_repo(host, rpm_path, args.pkey, args.gpgpass)
+                update_repo(host, release, dist, args.pkey)
             if srpms_released and update:
-                update_repo(host, srpm_path, args.pkey, args.gpgpass)
+                update_repo(host, release, dist, args.pkey)
 
 if __name__ == '__main__':
     main()

--- a/repo-update.sh
+++ b/repo-update.sh
@@ -12,93 +12,113 @@ function usage()
   echo "Usage repo-update.sh -r REPO -t [WEB|COMPUTE] -d DIST -a [ARCH]"
 
   echo "Required options:"
-  echo "  -r REPO     Repo to update (eg: 'latest', '2.1', 'build/2.1')"
-  echo "  -d DIST     Distribution to update (eg: 'el7', 'el8', 'focal')"
+  echo "  -r REPO       Repo to update (eg: 'latest', '2.1', 'build/2.1')"
+  echo "  -d DIST       Distribution to update (eg: 'el7', 'el8', 'focal')"
   echo
   echo "Optional options:"
-	echo "  -g GPGPASS  The path to GPG password file (default ${GPGPASS})"
-  echo "  -t TYPE     Type of repo to update, either web or compute (default: ${TYPE})"
-	echo "  -a ARCH     Arch to update (default: ${ARCH})"
+  echo "  -g GPGPASS    The path to GPG password file (default ${GPGPASS})"
+  echo "  -t TYPE       Type of repo to update, either web or compute (default: ${TYPE})"
+  echo "  -a ARCH       Arch to update (default: ${ARCH})"
 }
 
 while getopts "r:t:d:a:g:" opt; do
-	case "${opt}" in
-		r)
-			REPO="${OPTARG}"
-			;;
-		t)
-			TYPE="${OPTARG}"
-			;;
-		d)
-			DIST="${OPTARG}"
-			;;
-		a)
-			ARCH="${OPTARG}"
-			;;
-		g)
-			GPGPASS="${OPTARG}"
-			;;
-		*)
-			usage
-			exit
-			;;
-	esac
+  case "${opt}" in
+    r)
+      REPO="${OPTARG}"
+      ;;
+    t)
+      TYPE="${OPTARG}"
+      ;;
+    d)
+      DIST="${OPTARG}"
+      ;;
+    a)
+      ARCH="${OPTARG}"
+      ;;
+    g)
+      GPGPASS="${OPTARG}"
+      ;;
+    *)
+      usage
+      exit
+      ;;
+  esac
 done
 shift $((OPTIND-1))
 
 do_hash() {
-	HASH_NAME=$1
-	HASH_CMD=$2
-	echo "${HASH_NAME}:"
-	for f in $(find -type f); do
-		f=$(echo $f | cut -c3-) # remove ./ prefix
-		if [[ "$(basename $f)" != "Packages"* ]]; then
-			continue
-		fi
-		echo " $(${HASH_CMD} ${f}  | cut -d" " -f1) $(wc -c $f)"
-	done
+  HASH_NAME=$1
+  HASH_CMD=$2
+  echo "${HASH_NAME}:"
+  for f in $(find -type f); do
+    f=$(echo $f | cut -c3-) # remove ./ prefix
+    if [[ "$(basename $f)" != "Packages"* ]]; then
+      continue
+    fi
+    echo " $(${HASH_CMD} ${f}  | cut -d" " -f1) $(wc -c $f)"
+  done
 }
+
+if [[ "${USER}" != "oodpkg" ]]; then
+  echo "Must run as oodpkg user"
+  exit 1
+fi
 
 EL=true
 if [[ "${DIST}" != "el"* ]]; then
-	EL=false
+  EL=false
 fi
 
-if $EL; then
-	REPO_PATH="${BASE_PATH}/${REPO}/${TYPE}/${DIST}/${ARCH}"
-	echo "level=\"info\" msg=\"Update repo\" repo=\"${REPO_PATH}\""
-	cd ${REPO_PATH}
-	createrepo_c --update .
-	echo "level=\"info\" msg=\"GPG sign repo\" repo=\"${REPO_PATH}\""
-	gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor repodata/repomd.xml
+if [[ "x${REPO_PATH}" = "x" ]]; then
+  LOCK_NAME="$(echo '${REPO}-${TYPE}-${DIST}-${ARCH}' | md5sum | cut -d' ' -f1)"
 else
-	case "${DIST}" in
-	ubuntu-20.04|focal)
-		DIST="focal"
-		;;
-	*)
-		echo "Unrecognized DIST"
-		exit 1
-		;;
-	esac
-	case "${ARCH}" in
-	x86_64)
-		ARCH="amd64"
-		;;
-	*)
-		echo "Unrecognized ARCH"
-		exit 1
-		;;
-	esac
-	REPO_PATH="${BASE_PATH}/${REPO}/${TYPE}/apt"
-	DIST_PATH="${REPO_PATH}/dists/${DIST}"
-	echo "level=\"info\" msg=\"Scan packages repo\" repo=\"${REPO_PATH}\""
-	pushd ${REPO_PATH}
-	dpkg-scanpackages --arch ${ARCH} pool/${DIST} > dists/${DIST}/main/binary-${ARCH}/Packages
-	cat dists/${DIST}/main/binary-${ARCH}/Packages | gzip -9 > dists/${DIST}/main/binary-${ARCH}/Packages.gz
-	echo "level=\"info\" msg=\"Update Release\" repo=\"${DIST_PATH}\""
-	pushd ${DIST_PATH}
-	cat > Release <<EOF
+  LOCK_NAME="$(echo '${REPO_PATH}' | md5sum | cut -d' ' -f1)"
+fi
+LOCK_FILE="/var/lib/oodpkg/repo-update-${LOCK_NAME}.lock"
+
+(
+  flock -x -w 30 200
+  if $EL; then
+    REPO_PATH="${BASE_PATH}/${REPO}/${TYPE}/${DIST}/${ARCH}"
+    SRPM_PATH="${BASE_PATH}/${REPO}/${TYPE}/${DIST}/SRPMS"
+    echo "level=\"info\" msg=\"Update repo\" repo=\"${REPO_PATH}\""
+    cd ${REPO_PATH}
+    createrepo_c --update .
+    echo "level=\"info\" msg=\"GPG sign repo\" repo=\"${REPO_PATH}\""
+    gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor repodata/repomd.xml
+    echo "level=\"info\" msg=\"Update repo\" repo=\"${SRPM_PATH}\""
+    cd ${SRPM_PATH}
+    createrepo_c --update .
+    echo "level=\"info\" msg=\"GPG sign repo\" repo=\"${SRPM_PATH}\""
+    gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor repodata/repomd.xml
+  else
+    case "${DIST}" in
+    ubuntu-20.04|focal)
+      DIST="focal"
+      ;;
+    *)
+      echo "Unrecognized DIST"
+      exit 1
+      ;;
+    esac
+    case "${ARCH}" in
+    x86_64)
+      ARCH="amd64"
+      ;;
+    *)
+      echo "Unrecognized ARCH"
+      exit 1
+      ;;
+    esac
+    REPO_PATH="${BASE_PATH}/${REPO}/${TYPE}/apt"
+    DIST_PATH="${REPO_PATH}/dists/${DIST}"
+    echo "level=\"info\" msg=\"Scan packages repo\" repo=\"${REPO_PATH}\""
+    pushd ${REPO_PATH}
+    dpkg-scanpackages --arch ${ARCH} pool/${DIST} > dists/${DIST}/main/binary-${ARCH}/Packages
+    cat dists/${DIST}/main/binary-${ARCH}/Packages | gzip -9 > dists/${DIST}/main/binary-${ARCH}/Packages.gz
+    echo "level=\"info\" msg=\"Update Release\" repo=\"${DIST_PATH}\""
+    pushd ${DIST_PATH}
+    cat > Release <<EOF
 Origin: OnDemand Repository
 Label: OnDemand
 Suite: stable
@@ -112,7 +132,12 @@ $(do_hash "MD5Sum" "md5sum")
 $(do_hash "SHA1" "sha1sum")
 $(do_hash "SHA256" "sha256sum")
 EOF
-	echo "level=\"info\" msg=\"GPG sign Release\" repo=\"${DIST_PATH}\""
-	cat Release | gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --digest-algo SHA256 --cert-digest-algo SHA256 --armor > Release.gpg
-	cat Release | gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor --digest-algo SHA256 --cert-digest-algo SHA256 --clearsign > InRelease
-fi
+    echo "level=\"info\" msg=\"GPG sign Release\" repo=\"${DIST_PATH}\""
+    cat Release | gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --digest-algo SHA256 --cert-digest-algo SHA256 --armor > Release.gpg
+    cat Release | gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor --digest-algo SHA256 --cert-digest-algo SHA256 --clearsign > InRelease
+  fi
+) 200>${LOCK_FILE}
+
+RETVAL=$?
+
+exit $RETVAL

--- a/repo-update.sh
+++ b/repo-update.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+GPGPASS="/systems/osc_certs/gpg/ondemand/.gpgpass"
+BASE_PATH="/var/www/repos/public/ondemand"
+REPO=""
+TYPE="web"
+DIST=""
+ARCH="x86_64"
+
+function usage()
+{
+  echo "Usage repo-update.sh -r REPO -t [WEB|COMPUTE] -d DIST -a [ARCH]"
+
+  echo "Required options:"
+  echo "  -r REPO     Repo to update (eg: 'latest', '2.1', 'build/2.1')"
+  echo "  -d DIST     Distribution to update (eg: 'el7', 'el8', 'focal')"
+  echo
+  echo "Optional options:"
+	echo "  -g GPGPASS  The path to GPG password file (default ${GPGPASS})"
+  echo "  -t TYPE     Type of repo to update, either web or compute (default: ${TYPE})"
+	echo "  -a ARCH     Arch to update (default: ${ARCH})"
+}
+
+while getopts "r:t:d:a:g:" opt; do
+	case "${opt}" in
+		r)
+			REPO="${OPTARG}"
+			;;
+		t)
+			TYPE="${OPTARG}"
+			;;
+		d)
+			DIST="${OPTARG}"
+			;;
+		a)
+			ARCH="${OPTARG}"
+			;;
+		g)
+			GPGPASS="${OPTARG}"
+			;;
+		*)
+			usage
+			exit
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
+do_hash() {
+	HASH_NAME=$1
+	HASH_CMD=$2
+	echo "${HASH_NAME}:"
+	for f in $(find -type f); do
+		f=$(echo $f | cut -c3-) # remove ./ prefix
+		if [[ "$(basename $f)" != "Packages"* ]]; then
+			continue
+		fi
+		echo " $(${HASH_CMD} ${f}  | cut -d" " -f1) $(wc -c $f)"
+	done
+}
+
+EL=true
+if [[ "${DIST}" != "el"* ]]; then
+	EL=false
+fi
+
+if $EL; then
+	REPO_PATH="${BASE_PATH}/${REPO}/${TYPE}/${DIST}/${ARCH}"
+	echo "level=\"info\" msg=\"Update repo\" repo=\"${REPO_PATH}\""
+	cd ${REPO_PATH}
+	createrepo_c --update .
+	echo "level=\"info\" msg=\"GPG sign repo\" repo=\"${REPO_PATH}\""
+	gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor repodata/repomd.xml
+else
+	case "${DIST}" in
+	ubuntu-20.04|focal)
+		DIST="focal"
+		;;
+	*)
+		echo "Unrecognized DIST"
+		exit 1
+		;;
+	esac
+	case "${ARCH}" in
+	x86_64)
+		ARCH="amd64"
+		;;
+	*)
+		echo "Unrecognized ARCH"
+		exit 1
+		;;
+	esac
+	REPO_PATH="${BASE_PATH}/${REPO}/${TYPE}/apt"
+	DIST_PATH="${REPO_PATH}/dists/${DIST}"
+	echo "level=\"info\" msg=\"Scan packages repo\" repo=\"${REPO_PATH}\""
+	pushd ${REPO_PATH}
+	dpkg-scanpackages --arch ${ARCH} pool/${DIST} > dists/${DIST}/main/binary-${ARCH}/Packages
+	cat dists/${DIST}/main/binary-${ARCH}/Packages | gzip -9 > dists/${DIST}/main/binary-${ARCH}/Packages.gz
+	echo "level=\"info\" msg=\"Update Release\" repo=\"${DIST_PATH}\""
+	pushd ${DIST_PATH}
+	cat > Release <<EOF
+Origin: OnDemand Repository
+Label: OnDemand
+Suite: stable
+Codename: ${DIST}
+Version: ${REPO}
+Architectures: amd64
+Components: main
+Description: OnDemand repository
+Date: $(date -Ru)
+$(do_hash "MD5Sum" "md5sum")
+$(do_hash "SHA1" "sha1sum")
+$(do_hash "SHA256" "sha256sum")
+EOF
+	echo "level=\"info\" msg=\"GPG sign Release\" repo=\"${DIST_PATH}\""
+	cat Release | gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --digest-algo SHA256 --cert-digest-algo SHA256 --armor > Release.gpg
+	cat Release | gpg --detach-sign --passphrase-file ${GPGPASS} --batch --yes --no-tty --armor --digest-algo SHA256 --cert-digest-algo SHA256 --clearsign > InRelease
+fi


### PR DESCRIPTION
Fixes #149 

The idea here is to have a single bash script that gets executed on repo server that other scripts can call or can be used if ad-hoc fixes are needed to repos.  I opted for bash over Ruby because the current repo server is RHEL7 and that OS Ruby is still on 1.8.7 and didn't want to install and deal with a bunch of SCL packages on repo server.  When that system is upgraded to RHEL8 , can re-evaluate making the repo-update script into Ruby since be able to install newer Ruby via DNF modules.