### PR TITLE
Add nodejs to deb ondemand-release and ondemand-release-latest

### DIFF
--- a/packages/ondemand-release-latest/deb/Makefile
+++ b/packages/ondemand-release-latest/deb/Makefile
@@ -2,7 +2,7 @@ DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: tar
 TAR := tar
-VERSION := 1
+VERSION := 2
 
 tar:
 	mkdir -p $(DIR)/build

--- a/packages/ondemand-release-latest/deb/debian/control
+++ b/packages/ondemand-release-latest/deb/debian/control
@@ -2,7 +2,7 @@ Source: ondemand-release-latest
 Section: unknown
 Priority: optional
 Maintainer: Trey Dockendorf <tdockendorf@osc.edu>
-Build-Depends: debhelper (>=11~)
+Build-Depends: debhelper (>=11~), curl, gnupg
 Standards-Version: 4.1.4
 Homepage: https://github.com/OSC/ondemand-packaging
 

--- a/packages/ondemand-release-latest/deb/debian/postinst
+++ b/packages/ondemand-release-latest/deb/debian/postinst
@@ -3,3 +3,4 @@
 source /etc/os-release
 
 sed -i "s|@CODENAME@|$VERSION_CODENAME|g" /etc/apt/sources.list.d/ondemand-web.list
+sed -i "s|@CODENAME@|$VERSION_CODENAME|g" /etc/apt/sources.list.d/nodesource.list

--- a/packages/ondemand-release-latest/deb/debian/rules
+++ b/packages/ondemand-release-latest/deb/debian/rules
@@ -4,6 +4,7 @@ export DH_VERBOSE = 1
 export CODENAME = $(shell lsb_release -sc)
 export WEB_DESTDIR = $(CURDIR)/debian/ondemand-release-web-latest
 export DEB_BUILD_OPTIONS=nocheck
+export NODEREPO=node_14.x
 
 %:
 	dh $@
@@ -16,6 +17,8 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p $(WEB_DESTDIR)/etc/apt/sources.list.d
-	echo "deb [arch=amd64] https://apt.osc.edu/ondemand/latest/web/apt @CODENAME@ main" > $(WEB_DESTDIR)/etc/apt/sources.list.d/ondemand-web.list
 	mkdir -p $(WEB_DESTDIR)/etc/apt/trusted.gpg.d
+	echo "deb [arch=amd64] https://apt.osc.edu/ondemand/latest/web/apt @CODENAME@ main" > $(WEB_DESTDIR)/etc/apt/sources.list.d/ondemand-web.list
 	install -m 644 -D $(CURDIR)/ondemand.gpg $(WEB_DESTDIR)/etc/apt/trusted.gpg.d/ondemand-web.gpg
+	echo "deb https://deb.nodesource.com/$(NODEREPO) @CODENAME@ main" > $(WEB_DESTDIR)/etc/apt/sources.list.d/nodesource.list
+	curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > $(WEB_DESTDIR)/etc/apt/trusted.gpg.d/nodesource.gpg

--- a/packages/ondemand-release/deb/debian/control
+++ b/packages/ondemand-release/deb/debian/control
@@ -2,7 +2,7 @@ Source: ondemand-release
 Section: unknown
 Priority: optional
 Maintainer: Trey Dockendorf <tdockendorf@osc.edu>
-Build-Depends: debhelper (>=11~)
+Build-Depends: debhelper (>=11~), curl, gnupg
 Standards-Version: 4.1.4
 Homepage: https://github.com/OSC/ondemand-packaging
 

--- a/packages/ondemand-release/deb/debian/postinst
+++ b/packages/ondemand-release/deb/debian/postinst
@@ -3,3 +3,4 @@
 source /etc/os-release
 
 sed -i "s|@CODENAME@|$VERSION_CODENAME|g" /etc/apt/sources.list.d/ondemand-web.list
+sed -i "s|@CODENAME@|$VERSION_CODENAME|g" /etc/apt/sources.list.d/nodesource.list

--- a/packages/ondemand-release/deb/debian/rules
+++ b/packages/ondemand-release/deb/debian/rules
@@ -5,6 +5,7 @@ export CODENAME = $(shell lsb_release -sc)
 export WEB_DESTDIR = $(CURDIR)/debian/ondemand-release-web
 export DEB_BUILD_OPTIONS=nocheck
 export REPO=2.1
+export NODEREPO=node_14.x
 
 %:
 	dh $@
@@ -17,6 +18,8 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p $(WEB_DESTDIR)/etc/apt/sources.list.d
-	echo "deb [arch=amd64] https://apt.osc.edu/ondemand/$(REPO)/web/apt @CODENAME@ main" > $(WEB_DESTDIR)/etc/apt/sources.list.d/ondemand-web.list
 	mkdir -p $(WEB_DESTDIR)/etc/apt/trusted.gpg.d
+	echo "deb [arch=amd64] https://apt.osc.edu/ondemand/$(REPO)/web/apt @CODENAME@ main" > $(WEB_DESTDIR)/etc/apt/sources.list.d/ondemand-web.list
 	install -m 644 -D $(CURDIR)/ondemand.gpg $(WEB_DESTDIR)/etc/apt/trusted.gpg.d/ondemand-web.gpg
+	echo "deb https://deb.nodesource.com/$(NODEREPO) @CODENAME@ main" > $(WEB_DESTDIR)/etc/apt/sources.list.d/nodesource.list
+	curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > $(WEB_DESTDIR)/etc/apt/trusted.gpg.d/nodesource.gpg


### PR DESCRIPTION
In response to https://github.com/OSC/ondemand/issues/1654

Built deb for ondemand-release-latest and tested locally:

```
$ docker run --rm -it -v /tmp/output2:/output ubuntu:20.04 /bin/bash
# apt update
# apt install /output/ubuntu-20.04/ondemand-release-web-latest_2_all.deb
# apt install apt-transport-https ca-certificates
# apt update
# apt install nodejs
# node --version
v14.18.2
```

Deb package uploaded here: https://apt.osc.edu/ondemand/latest/ondemand-release-web-latest_2_all.deb - will update ondemand repo to use this shortly.