### PR TITLE
Avoid installing gems into system gem path

### DIFF
--- a/lib/ood_packaging/build.rb
+++ b/lib/ood_packaging/build.rb
@@ -130,6 +130,7 @@ class OodPackaging::Build
   end
 
   def run!
+    fix_env!
     env_dump! if debug?
     bootstrap_rpm! if build_box.rpm?
     bootstrap_deb! if build_box.deb?
@@ -139,6 +140,10 @@ class OodPackaging::Build
     copy_output!
     gpg_sign! if build_box.rpm? && gpg_sign?
     sanity!
+  end
+
+  def fix_env!
+    ENV.delete('GEM_PATH')
   end
 
   def env_dump!

--- a/lib/ood_packaging/build_box/docker-image/Dockerfile.erb
+++ b/lib/ood_packaging/build_box/docker-image/Dockerfile.erb
@@ -2,6 +2,7 @@ FROM <%= base_image %>
 MAINTAINER Trey Dockendorf <tdockendorf@osc.edu>
 ENV LANG=en_US.UTF-8
 ENV LC_CTYPE=en_US.UTF-8
+ENV GEM_PATH=<%= ctr_gems_dir %>:
 <% if dist == 'el7' -%>
 RUN yum update -y && yum clean all && rm -rf /var/cache/yum/*
 RUN yum install -y yum-utils epel-release centos-release-scl && yum clean all && rm -rf /var/cache/yum/*

--- a/lib/ood_packaging/build_box/docker-image/install.sh.erb
+++ b/lib/ood_packaging/build_box/docker-image/install.sh.erb
@@ -73,9 +73,9 @@ echo "allow-loopback-pinentry" >> <%= ctr_gpg_dir %>/gpg-agent.conf
 
 header "Install ood_packaging gem"
 <%- if rpm? && !dnf? -%>
-run scl enable <%= scl_ruby %> -- gem install --no-doc /build/*.gem
+run scl enable <%= scl_ruby %> -- gem install --no-doc --bindir <%= ctr_scripts_dir %> --install-dir <%= ctr_gems_dir %> /build/*.gem
 <%- else -%>
-run gem install --no-doc /build/*.gem
+run gem install --no-doc --bindir <%= ctr_scripts_dir %> --install-dir <%= ctr_gems_dir %> /build/*.gem
 <%- end -%>
 
 header "Copy in launch scripts"

--- a/lib/ood_packaging/package.rb
+++ b/lib/ood_packaging/package.rb
@@ -157,7 +157,7 @@ class OodPackaging::Package
     cmd = []
     cmd.concat exec_launchers if docker_runtime?
     cmd.concat ['scl', 'enable', scl_ruby, '--'] if podman_runtime? && build_box.scl?
-    cmd.concat ['rake']
+    cmd.concat [File.join(ctr_scripts_dir, 'rake')]
     cmd.concat ['-q'] unless debug
     cmd.concat ['-f', File.join(ctr_scripts_dir, 'Rakefile'), 'ood_packaging:package:build']
     cmd

--- a/lib/ood_packaging/utils.rb
+++ b/lib/ood_packaging/utils.rb
@@ -67,6 +67,10 @@ module OodPackaging::Utils
     '/ondemand-packaging'
   end
 
+  def ctr_gems_dir
+    File.join(ctr_scripts_dir, 'gems')
+  end
+
   def gpg_private_key
     File.join(ctr_scripts_dir, 'ondemand.sec')
   end

--- a/spec/ood_packaging/package_spec.rb
+++ b/spec/ood_packaging/package_spec.rb
@@ -158,7 +158,7 @@ describe OodPackaging::Package do
         '-e', "'OOD_UID=1000'", '-e', "'OOD_GID=1000'",
         '-e', "'DEBUG=false'", '-e', "'VERSION=0.0.1'",
         'uuid', '/ondemand-packaging/inituidgid.sh', '/ondemand-packaging/setuser.rb', 'ood',
-        'rake', '-q', '-f', '/ondemand-packaging/Rakefile', 'ood_packaging:package:build'
+        '/ondemand-packaging/rake', '-q', '-f', '/ondemand-packaging/Rakefile', 'ood_packaging:package:build'
       ]
       expect(package).to receive(:sh).with(expected_command.join(' '), verbose: false)
       package.container_exec!(package.exec_rake)


### PR DESCRIPTION
Ensures when other packages build using the container, there are not left over gems from build box creation