### PR TITLE
Ensure USER is set inside container

### DIFF
--- a/lib/ood_packaging/build_box/docker-image/Dockerfile.erb
+++ b/lib/ood_packaging/build_box/docker-image/Dockerfile.erb
@@ -2,6 +2,7 @@ FROM <%= base_image %>
 MAINTAINER Trey Dockendorf <tdockendorf@osc.edu>
 ENV LANG=en_US.UTF-8
 ENV LC_CTYPE=en_US.UTF-8
+ENV USER=<%= ctr_user %>
 ENV GEM_PATH=<%= ctr_gems_dir %>:
 <% if dist == 'el7' -%>
 RUN yum update -y && yum clean all && rm -rf /var/cache/yum/*


### PR DESCRIPTION
@johrstrom I think this is all that's needed to fix podman. It seems `dh_make` which bootstraps build expects `USER` or `LOGNAME` to be set , at least those are errors I saw when testing with podman on build-el8.

I was able to test this out by taking this fix and doing this at root of this repo:

```
bundle exec rake ood_packaging:buildbox:build[ubuntu-20.04] CONTAINER_RT=podman
```

Then with ondemand I did this:

```
bundle exec rake package:build[ubuntu-20.04] CONTAINER_RT=podman OOD_PACKAGING_DEBUG=true
```
Fixes #192 