### PR TITLE
Build websockify against Python 3 and update version to 0.10.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,9 +196,18 @@ build-turbovnc:
 package-deploy-latest:
   stage: deploy
   rules:
-    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG !~ /v[0-9].+/
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG !~ /v[0-9].+/ && $CI_COMMIT_TAG !~ /turbovnc|python-websockify|ondemand-compute/
   script:
     - ./release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*
+
+package-deploy-latest-compute:
+  stage: deploy
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^turbovnc-/'
+    - if: '$CI_COMMIT_TAG =~ /^python-websockify-/'
+    - if: '$CI_COMMIT_TAG =~ /^ondemand-compute-/'
+  script:
+    - ./release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c compute ./tmp/output/*
 
 package-deploy-build:
   stage: deploy

--- a/lib/ood_packaging/version.rb
+++ b/lib/ood_packaging/version.rb
@@ -22,7 +22,7 @@ module OodPackaging
       '(ubuntu|debian)' => '2.1.0',
       'default'         => '2.1'
     },
-    'python-websockify'       => '0.8.0',
+    'python-websockify'       => '0.10.0',
     'turbovnc'                => '2.2.5'
   }.freeze
 

--- a/lib/ood_packaging/version.rb
+++ b/lib/ood_packaging/version.rb
@@ -20,7 +20,7 @@ module OodPackaging
     'ondemand_exporter'       => '0.9.0',
     'ondemand-compute'        => {
       '(ubuntu|debian)' => '2.1.0',
-      'default'         => '2.1'
+      'default'         => '2.1.0'
     },
     'python-websockify'       => '0.10.0',
     'turbovnc'                => '2.2.5'

--- a/packages/ondemand-compute/rpm/ondemand-compute.spec
+++ b/packages/ondemand-compute/rpm/ondemand-compute.spec
@@ -11,7 +11,7 @@ URL:        https://osc.github.io/ood-documentation/
 BuildArch:  noarch
 
 Requires:   turbovnc >= 2.2.5
-Requires:   python-websockify >= 0.8.0
+Requires:   python3-websockify >= 0.10.0
 Requires:   /bin/bash
 Requires:   /usr/bin/shuf
 Requires:   /usr/bin/pgrep

--- a/packages/python-websockify/rpm/python-websockify.spec
+++ b/packages/python-websockify/rpm/python-websockify.spec
@@ -10,15 +10,9 @@ License:        LGPLv3
 URL:            https://github.com/novnc/websockify
 Source0:        https://github.com/novnc/websockify/archive/refs/tags/v%{package_version}.tar.gz
 BuildArch:      noarch
-BuildRequires:  python2-devel
-BuildRequires:  python2-rpm-macros
-%if 0%{?rhel} >= 8
-BuildRequires:  python2-setuptools
-Requires:       python2-setuptools
-%else
-BuildRequires:  python-setuptools
-Requires:       python-setuptools
-%endif
+BuildRequires:  python3-rpm-macros
+BuildRequires:  python3-setuptools
+Requires:       python3-setuptools
 
 %description
 Python WSGI based adapter for the Websockets protocol
@@ -30,11 +24,11 @@ Python WSGI based adapter for the Websockets protocol
 sed -i '/setup_requires/d; /install_requires/d; /dependency_links/d' setup.py
 
 %build
-%{__python2} setup.py build
+%{__python3} setup.py build
 
 
 %install
-%{__python2} setup.py install -O1 --skip-build --root %{buildroot}
+%{__python3} setup.py install -O1 --skip-build --root %{buildroot}
 
 rm -Rf %{buildroot}/usr/share/websockify
 mkdir -p %{buildroot}%{_mandir}/man1/
@@ -42,10 +36,10 @@ install -m 444 docs/websockify.1 %{buildroot}%{_mandir}/man1/
 
 
 %files
-%doc LICENSE.txt docs
+%doc docs
 %{_mandir}/man1/websockify.1*
-%{python2_sitelib}/websockify/*
-%{python2_sitelib}/websockify-%{version}-py?.?.egg-info
+%{python3_sitelib}/websockify/*
+%{python3_sitelib}/websockify-%{version}-py?.?.egg-info
 %{_bindir}/websockify
 
 

--- a/packages/python-websockify/rpm/python-websockify.spec
+++ b/packages/python-websockify/rpm/python-websockify.spec
@@ -1,7 +1,7 @@
 %{!?package_release: %define package_release 1}
 %define __brp_mangle_shebangs /bin/true
 
-Name:           python-websockify
+Name:           python3-websockify
 Version:        %{package_version}
 Release:        %{package_release}%{?dist}
 Summary:        WSGI based adapter for the Websockets protocol
@@ -13,6 +13,7 @@ BuildArch:      noarch
 BuildRequires:  python3-rpm-macros
 BuildRequires:  python3-setuptools
 Requires:       python3-setuptools
+Obsoletes:      python-websockify
 
 %description
 Python WSGI based adapter for the Websockets protocol

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -91,7 +91,7 @@ ondemand_exporter:
 ondemand-compute:
   - '{major}-1'
 python-websockify:
-  - 0.8.0-1
+  - 0.10.0-1
 turbovnc:
   packages:
     - turbovnc

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -89,8 +89,8 @@ ondemand_exporter:
 
 # compute
 ondemand-compute:
-  - '{major}-1'
-python-websockify:
+  - '{major}.0-1'
+python3-websockify:
   - 0.10.0-1
 turbovnc:
   packages:


### PR DESCRIPTION
Ensure compute package release goes to correct repo
Fixes #212