### PR TITLE
only copy gpg if gpg signing is enabled

### DIFF
--- a/lib/ood_packaging/build.rb
+++ b/lib/ood_packaging/build.rb
@@ -166,7 +166,8 @@ class OodPackaging::Build
     bootstrap_gpg! if gpg_sign?
     if podman_runtime?
       puts "\tBootstrap /root".blue
-      sh "cp -r #{ctr_rpmmacros} #{ctr_gpg_dir} /root/"
+      sh "cp -r #{ctr_rpmmacros} /root/"
+      sh "cp -r #{ctr_gpg_dir} /root/" if gpg_sign?
       sh "sed -i 's|/home/ood|/root|g' /root/.rpmmacros"
     end
     puts "\tBootstrap work dir".blue

--- a/lib/ood_packaging/build.rb
+++ b/lib/ood_packaging/build.rb
@@ -167,7 +167,7 @@ class OodPackaging::Build
     if podman_runtime?
       puts "\tBootstrap /root".blue
       sh "cp -r #{ctr_rpmmacros} /root/"
-      sh "cp -r #{ctr_gpg_dir} /root/" if gpg_sign?
+      sh "cp -r #{ctr_gpg_dir} /root/" if gpg_sign? && build_box.dnf?
       sh "sed -i 's|/home/ood|/root|g' /root/.rpmmacros"
     end
     puts "\tBootstrap work dir".blue


### PR DESCRIPTION
This fixes #232 for me using podman. I assume `bootstrap_gpg!` initializes `~/.gnupg` (I didn't test GPG signing).