### PR TITLE
Specific httpd

### DIFF
--- a/lib/ood_packaging/version.rb
+++ b/lib/ood_packaging/version.rb
@@ -12,7 +12,7 @@ module OodPackaging
       '(ubuntu|debian)' => '4',
       'default'         => '1-8'
     },
-    'ondemand-runtime'        => '3.1.5',
+    'ondemand-runtime'        => '3.1.6',
     'scl-utils'               => '2.0.3',
     'passenger'               => '6.0.20',
     'cjose'                   => '0.6.1',

--- a/packages/ondemand-runtime/rpm/ondemand-runtime.spec
+++ b/packages/ondemand-runtime/rpm/ondemand-runtime.spec
@@ -104,14 +104,18 @@ Meta package for pulling in SCL nodejs %{nodejs}
 
 %package -n ondemand-apache
 Summary: Meta package for pulling in SCL apache %{apache}
+%if 0%{?rhel} == 8
+Requires: %{apache} > 2.4.37-56, %{apache} < 2.5
+%endif
+%if 0%{?rhel} == 9
+Requires: %{apache} > 2.4.57-8, %{apache} < 2.5
+%endif
 %if 0%{?rhel} >= 8
-Requires: %{apache} >= 2.4, %{apache} < 2.5
 Requires: httpd-devel
 Requires: mod_ssl
 Requires: mod_ldap
 %endif
 %if 0%{?amzn} == 2023
-Requires: %{apache} >= 2.4, %{apache} < 2.5
 Requires: httpd-devel
 Requires: mod_ssl
 Requires: mod_ldap

--- a/packages/ondemand-runtime/rpm/ondemand-runtime.spec
+++ b/packages/ondemand-runtime/rpm/ondemand-runtime.spec
@@ -116,6 +116,7 @@ Requires: mod_ssl
 Requires: mod_ldap
 %endif
 %if 0%{?amzn} == 2023
+Requires: %{apache} >= 2.4, %{apache} < 2.5
 Requires: httpd-devel
 Requires: mod_ssl
 Requires: mod_ldap

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -1,6 +1,6 @@
 major: '3.1'
 full: '3.1.9'
-runtime: '3.1.5'
+runtime: '3.1.6'
 
 # release
 ondemand-release:


### PR DESCRIPTION
specify more specific versions of httpd for el 8 & 9 to close out some bugs on the OnDemand repo.

Specifically https://github.com/OSC/ondemand/issues/3878 and https://github.com/OSC/ondemand/issues/3894. 

I basically just took what you'd given Trey and added it here. Happy to fix it up as you see appropriate. 