### PR TITLE
add libyaml-dev to debian

### DIFF
--- a/lib/ood_packaging/build_box/docker-image/Dockerfile.erb
+++ b/lib/ood_packaging/build_box/docker-image/Dockerfile.erb
@@ -40,7 +40,7 @@ RUN apt update -y && apt install -y locales && \
     apt clean all -y
 RUN apt update -y && apt install -y apt-transport-https ca-certificates \
     init debhelper devscripts dh-make build-essential apt-cudf lintian equivs \
-    sudo rake wget curl ruby bundler && \
+    sudo rake wget curl ruby bundler libyaml-dev && \
     apt clean all -y
 RUN echo "deb https://deb.nodesource.com/node_<%= nodejs_version %>.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nodesource.gpg


### PR DESCRIPTION
add libyaml-dev to debian to fix debian builds after updating some gems in OOD.

Note EL builds in the same PR (https://github.com/OSC/ondemand/pull/4222) are failing for a different reason, the OnDemand CI is very broken and we have the GOOD conference next week.

Which is to say, there's no rush to publish this update. I'll circle back after the conference.