### PR TITLE
Move procps-ng requirement from Nginx to Passenger

### DIFF
--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -58,6 +58,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  pcre-devel
 Requires: ondemand-runtime = %{runtime_version}
 Requires: ondemand-ruby = %{runtime_version}
+Requires: procps-ng
 Provides: %{name} = %{version}-%{release}
 Provides: bundled(boost)  = %{bundled_boost_version}
 
@@ -101,7 +102,6 @@ BuildRequires: libev-devel >= 4.0.0
 Requires: gd
 Requires: openssl
 Requires: pcre
-Requires: procps-ng
 
 %description -n %{?scl_prefix}nginx
 Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and


### PR DESCRIPTION
- Move the requirement for correctness. It probably has little impact on the end result though.
- Greetings from the GOOD 2025 Contributor Jam!