### PR TITLE
Passenger RPM: Allow overriding analytics sleep behavior

### DIFF
--- a/lib/ood_packaging/build_box/docker-image/install.sh.erb
+++ b/lib/ood_packaging/build_box/docker-image/install.sh.erb
@@ -41,6 +41,7 @@ Defaults:<%= ctr_user %> !requiretty, !authenticate
 %<%= ctr_user %> ALL=NOPASSWD:ALL
 EOF
 run chmod 440 /etc/sudoers.d/ood
+run chmod 600 /etc/shadow
 
 <% if rpm? -%>
 header "Setup RPM env"

--- a/packages/passenger/rpm/passenger-analytics-collection-static-sleep.patch
+++ b/packages/passenger/rpm/passenger-analytics-collection-static-sleep.patch
@@ -1,0 +1,52 @@
+--- a/src/agent/Core/ApplicationPool/Pool/AnalyticsCollection.cpp	2025-03-18 14:46:32.727000000 +0200
++++ b/src/agent/Core/ApplicationPool/Pool/AnalyticsCollection.cpp	2025-03-18 15:40:10.139000000 +0200
+@@ -23,6 +23,9 @@
+  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  *  THE SOFTWARE.
+  */
++#include <cstdlib> // getenv
++#include <climits> // INT_MAX
++
+ #include <Core/ApplicationPool/Pool.h>
+ 
+ /*************************************************************************
+@@ -62,8 +65,39 @@
+ 		}
+ 
+ 		UPDATE_TRACE_POINT();
++
+ 		unsigned long long currentTime = SystemTime::getUsec();
+ 		unsigned long long sleepTime = timeToNextMultipleULL(5000000, currentTime);
++		// Open OnDemand override: Use a static OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME seconds sleep time
++		// if it is defined. Try reading from the environment variable.
++		// If this is undefined, or invalid, use the upstream Passenger behavior (i.e., dynamic sleeping with 5 second intervals).
++		const char* envPassengerSleepTimeOverride = std::getenv("OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS");
++		if (envPassengerSleepTimeOverride) {
++			// The environment variable was defined. Check if it can be parsed as a number.
++			int sleepTimeOverride = INT_MAX; // initial value (use a smaller type to allow safe multiplication to ULL)
++			do {
++				// Convert to an ull and check for errors. Use the default in case of errors.
++				try {
++					sleepTimeOverride = std::stoi(envPassengerSleepTimeOverride);
++				} catch (const std::exception& e) {
++					// std::invalid_argument or std::out_of_range, stop here.
++					P_WARN("ERROR: Could not parse OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS value '" <<
++							envPassengerSleepTimeOverride << "' as an int. Will revert to upstream behavior.\n");
++					break;
++					// This will cause the upstream behavior to be used.
++				}
++				// If we got here, there was a valid int. Sanity check that it's > 0.
++				if (sleepTimeOverride != INT_MAX && sleepTimeOverride > 0) {
++					// Use this value. Multiply by 1M microseconds.
++					sleepTime = (unsigned long long)sleepTimeOverride * 1000000ULL;
++				}
++				// Otherwise, keep the default value.
++			} while (false);
++		}
++		// else {
++			// Upstream Passenger behavior
++			// This is a NOOP.
++		// }
+ 		P_DEBUG("Analytics collection done; next analytics collection in " <<
+ 			std::fixed << std::setprecision(3) << (sleepTime / 1000000.0) <<
+ 			" sec");

--- a/packages/passenger/rpm/passenger-analytics-collection-static-sleep.patch
+++ b/packages/passenger/rpm/passenger-analytics-collection-static-sleep.patch
@@ -25,7 +25,7 @@
 +			// The environment variable was defined. Check if it can be parsed as a number.
 +			int sleepTimeOverride = INT_MAX; // initial value (use a smaller type to allow safe multiplication to ULL)
 +			do {
-+				// Convert to an ull and check for errors. Use the default in case of errors.
++				// Convert to an int and check for errors. Use the default in case of errors.
 +				try {
 +					sleepTimeOverride = std::stoi(envPassengerSleepTimeOverride);
 +				} catch (const std::exception& e) {

--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -61,6 +61,7 @@ BuildRequires:  pcre-devel
 BuildRequires:  patch
 Requires: ondemand-runtime = %{runtime_version}
 Requires: ondemand-ruby = %{runtime_version}
+Requires: procps-ng
 Provides: %{name} = %{version}-%{release}
 Provides: bundled(boost)  = %{bundled_boost_version}
 
@@ -104,7 +105,6 @@ BuildRequires: libev-devel >= 4.0.0
 Requires: gd
 Requires: openssl
 Requires: pcre
-Requires: procps-ng
 
 %description -n %{?scl_prefix}nginx
 Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and

--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -46,6 +46,8 @@ License:    Boost and BSD and BSD with advertising and MIT and zlib
 Source0:    https://github.com/phusion/passenger/releases/download/release-%{passenger_version}/passenger-%{passenger_version}.tar.gz
 Source1:    http://nginx.org/download/nginx-%{nginx_version}.tar.gz
 
+Patch0:     passenger-analytics-collection-static-sleep.patch
+
 %{?scl:Requires:%scl_runtime}
 %{?scl:BuildRequires:%scl_runtime}
 BuildRequires:  ondemand-scldevel = %{runtime_version}
@@ -56,6 +58,7 @@ BuildRequires:  libcurl-devel
 BuildRequires:  zlib-devel
 BuildRequires:  openssl-devel
 BuildRequires:  pcre-devel
+BuildRequires:  patch
 Requires: ondemand-runtime = %{runtime_version}
 Requires: ondemand-ruby = %{runtime_version}
 Provides: %{name} = %{version}-%{release}
@@ -111,6 +114,9 @@ memory usage. Includes Phusion Passenger support.
 %prep
 %setup -q -n %{pkg_name}-%{passenger_version}
 %setup -q -T -D -a 1 -n %{pkg_name}-%{passenger_version}
+
+# Apply patches
+%patch -P0 -p1 -F1
 
 %build
 scl enable ondemand - << \EOF
@@ -362,3 +368,11 @@ fi
 %config(noreplace) %{nginx_confdir}/win-utf
 
 %changelog
+* Mon Mar 03 2025 Simon Westersund <swesters@csc.fi> [6.0.23-3]
+- Patch Passenger analytics collection to allow site admins
+  to avoid simultaneous wake-ups by all agents. This behavior can be
+  activated by defining a positive integer in the environment variable:
+  OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS.
+  This must be a value that fits into a positive signed int. Fractional
+  seconds are not supported. If the variable is undefined, or invalid,
+  the default Passenger behavior will be utilized.

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -32,7 +32,7 @@ ondemand-passenger:
     - ondemand-passenger-dev
     - ondemand-passenger-doc
   versions:
-    - 6.0.23-3.ood{runtime}
+    - 6.0.23-2.ood{runtime}
     # deb package
     - 6.0.23.ood{major}.1
 ondemand-runtime:

--- a/release-manifest.yaml
+++ b/release-manifest.yaml
@@ -32,7 +32,7 @@ ondemand-passenger:
     - ondemand-passenger-dev
     - ondemand-passenger-doc
   versions:
-    - 6.0.23-2.ood{runtime}
+    - 6.0.23-3.ood{runtime}
     # deb package
     - 6.0.23.ood{major}.1
 ondemand-runtime:


### PR DESCRIPTION
- Allow site admins to set an environment variable called 'OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS' with a positive, signed int as a value, to make Passenger sleep statically for the given amount of seconds, instead of dynamically sleeping around 5 seconds, like upstream Passenger has implemented it.
- Using a high value saves a lot of work, especially in containerized OOD deployments, where calling `ps` and performing a lot of syscalls will be have a higher impact.