### PR TITLE
Passenger patches for analytics to avoid dynamic sleeping by default

### DIFF
--- a/packages/passenger/rpm/passenger-analytics-collection-static-sleep.patch
+++ b/packages/passenger/rpm/passenger-analytics-collection-static-sleep.patch
@@ -1,0 +1,66 @@
+--- a/src/agent/Core/ApplicationPool/Pool/AnalyticsCollection.cpp    2025-03-28 15:04:27.371198726 +0200
++++ b/src/agent/Core/ApplicationPool/Pool/AnalyticsCollection.cpp    2025-03-28 15:06:10.586606453 +0200
+@@ -23,6 +23,9 @@
+  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  *  THE SOFTWARE.
+  */
++#include <cstdlib> // getenv
++#include <climits> // INT_MAX
++
+ #include <Core/ApplicationPool/Pool.h>
+ 
+ /*************************************************************************
+@@ -62,8 +65,51 @@
+		}
+ 
+		UPDATE_TRACE_POINT();
+-		unsigned long long currentTime = SystemTime::getUsec();
+-		unsigned long long sleepTime = timeToNextMultipleULL(5000000, currentTime);
++
++		// Open OnDemand override: Change the default sleeping behavior unless the following environment
++		// variable is defined: OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_RESTORE_UPSTREAM_BEHAVIOR.
++		// Use a static sleep of 5 seconds by default.
++		// This can be overridden with the OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS variable.
++		// NOTE: Setting this to a very big value will impact the usefulness of passenger-status metrics,
++		//       which will not get gathered unless this loop runs. If you do not care about the metrics,
++		//       feel free to set very large values.
++		const unsigned long long defaultSleepTime = 5000000;
++		unsigned long long sleepTime = defaultSleepTime;
++		const char* envPassengerRestoreUpstreamBehavior = std::getenv("OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_RESTORE_UPSTREAM_BEHAVIOR");
++		if (envPassengerRestoreUpstreamBehavior) {
++			// Upstream Passenger behavior
++			unsigned long long currentTime = SystemTime::getUsec();
++			sleepTime = timeToNextMultipleULL(5000000, currentTime);
++		} else {
++			// Open OnDemand override: Use a static OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME seconds sleep time
++			// Try reading from the environment variable. If this is undefined, or invalid, use the defaultSleepTime instead.
++			const char* envPassengerSleepTimeOverride = std::getenv("OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS");
++			int sleepTimeOverride = INT_MAX; // initial value (use a smaller type to allow safe multiplication to ULL)
++			do {
++				if (envPassengerSleepTimeOverride) {
++					// Convert to an ull and check for errors. Use the default in case of errors.
++					try {
++						sleepTimeOverride = std::stoi(envPassengerSleepTimeOverride);
++					} catch (const std::exception& e) {
++						// std::invalid_argument or std::out_of_range, stop here.
++						// Print loud warnings, since this is a misconfiguration by the site admin.
++						P_WARN("ERROR: Could not parse OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS value '"
++								<< envPassengerSleepTimeOverride << "' as an int. Using default "
++								<< defaultSleepTime << " seconds instead.\n"
++								<< "  Reason: " << e.what() << "\n");
++						break;
++					}
++					// If we got here, there was a valid int. Sanity check that it's > 0.
++					if (sleepTimeOverride != INT_MAX && sleepTimeOverride > 0) {
++						// Use this value. Multiply by 1M microseconds.
++						sleepTime = (unsigned long long)sleepTimeOverride * 1000000ULL;
++					}
++					// Otherwise, keep the default value.
++				}
++			} while (false);
++		}
++
++
+		P_DEBUG("Analytics collection done; next analytics collection in " <<
+			std::fixed << std::setprecision(3) << (sleepTime / 1000000.0) <<
+			" sec");

--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -46,6 +46,8 @@ License:    Boost and BSD and BSD with advertising and MIT and zlib
 Source0:    https://github.com/phusion/passenger/releases/download/release-%{passenger_version}/passenger-%{passenger_version}.tar.gz
 Source1:    http://nginx.org/download/nginx-%{nginx_version}.tar.gz
 
+Patch0:     passenger-analytics-collection-static-sleep.patch
+
 %{?scl:Requires:%scl_runtime}
 %{?scl:BuildRequires:%scl_runtime}
 BuildRequires:  ondemand-scldevel = %{runtime_version}
@@ -99,6 +101,7 @@ Obsoletes: %{?scl_prefix}nginx-filesystem
 BuildRequires: libxslt-devel
 BuildRequires: gd-devel
 BuildRequires: libev-devel >= 4.0.0
+BuildRequires: patch
 Requires: gd
 Requires: openssl
 Requires: pcre
@@ -111,6 +114,9 @@ memory usage. Includes Phusion Passenger support.
 %prep
 %setup -q -n %{pkg_name}-%{passenger_version}
 %setup -q -T -D -a 1 -n %{pkg_name}-%{passenger_version}
+
+# Apply patches
+%patch -P0 -p1 -F1
 
 %build
 scl enable ondemand - << \EOF
@@ -362,3 +368,15 @@ fi
 %config(noreplace) %{nginx_confdir}/win-utf
 
 %changelog
+
+* Fri Mar 28 2025 Simon Westersund <swesters@csc.fi> [6.0.23-3]
+- Patch Passenger analytics collection to sleep for 5 seconds by default,
+  to avoid simultaneous wake-ups by all agents. This behavior can be
+  restored to upstream defaults by defining the
+  OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_RESTORE_UPSTREAM_BEHAVIOR
+  environment variable (any value works).
+- Allow overriding the 5 second sleep time with
+  OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS. This
+  must be a value that fits into a positive signed int. Fractional
+  seconds are not supported.
+


### PR DESCRIPTION
- By default, sleep 5 seconds irrespectively, and avoid that all Passenger agents wake up at the same time to gather analytics.
- Allow restoring the default (dynamic) sleep behavior by defining the environment variable: OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_RESTORE_UPSTREAM_BEHAVIOR
  -  NOTE: any value of this variable is taken as true-ish, so setting it to "false" won't do what one might expect. Leave it undefined to deactivate this behavior.
  - This variable takes precendence over the sleep time variable.
- Allow overriding the 5 second default timer with OOD_OVERRIDE_PASSENGER_ANALYTICS_COLLECTION_SLEEP_TIME_SECONDS
  - The value must be a positive signed integer number of seconds.
  - If the value is invalid and cannot be parsed, log warnings from Passenger and revert to the default sleep time (i.e., 5 seconds static sleep). The warnings are an indication to site admins that their configuration is wrong, so this will either never happen, or happen every time (i.e., a lot of logging to indicate that something is wrong.)