### PR TITLE
chown these directories as they're done in .deb

### DIFF
--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -4,7 +4,7 @@
 %define passenger_version %{package_version}
 %define nginx_version 1.28.0
 %define release_version %{package_release}
-%define ngix_release_version 1
+%define ngix_release_version 2
 
 %define runtime_version 4.2.0
 

--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -312,6 +312,9 @@ if [ $1 -eq 2 ]; then
     chmod o-rwx %{nginx_home}
     chmod o-rwx %{nginx_home_tmp}
     chmod o-rwx %{nginx_logdir}
+    chown %{nginx_user}:%{nginx_group} %{nginx_home}
+    chown %{nginx_user}:%{nginx_group} %{nginx_home_tmp}
+    chown %{nginx_user}:%{nginx_group} %{nginx_logdir}
 fi
 
 %files


### PR DESCRIPTION
Debian packages `chown` these directories so the RPMs should likely do as well.

https://github.com/OSC/ondemand-packaging/blob/310bac2f62058705b47dff8c79bf9b7a38791706/packages/passenger/deb/debian/ondemand-nginx.postinst#L12-L14