### PR TITLE
Backport RPM chown directories to 4.2

### DIFF
--- a/packages/passenger/rpm/passenger.spec
+++ b/packages/passenger/rpm/passenger.spec
@@ -4,7 +4,7 @@
 %define passenger_version %{package_version}
 %define nginx_version 1.28.0
 %define release_version %{package_release}
-%define ngix_release_version 1
+%define ngix_release_version 2
 
 %define runtime_version 4.2.0
 
@@ -312,6 +312,9 @@ if [ $1 -eq 2 ]; then
     chmod o-rwx %{nginx_home}
     chmod o-rwx %{nginx_home_tmp}
     chmod o-rwx %{nginx_logdir}
+    chown %{nginx_user}:%{nginx_group} %{nginx_home}
+    chown %{nginx_user}:%{nginx_group} %{nginx_home_tmp}
+    chown %{nginx_user}:%{nginx_group} %{nginx_logdir}
 fi
 
 %files


### PR DESCRIPTION
Backports https://github.com/OSC/ondemand-packaging/pull/329 to 4.2 release branch.